### PR TITLE
[chore] Add angular-devkit/build-angular to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "zone.js": "~0.15.0"
   },
   "devDependencies": {
+    "@angular-devkit/build-angular": "^19.2.8",
     "@angular/cli": "^19.2.0",
     "@angular/compiler-cli": "^19.2.0",
     "@commitlint/cli": "^19.7.1",


### PR DESCRIPTION
A recent push to main appears to have broken the build, with the following error:
```
Step 7/13 : RUN ng build --verbose
 ---> Running in 335a801d453c
[91mError: Could not find the '@angular-devkit/build-angular:application' builder's node package.
```
Adding `angular-devkit/build-angular` to the `devDependencies` appears to resolve this issue and allow docker builds to succeed. 