### PR TITLE
 Updated the rules to prevent a merge with changes requested

### DIFF
--- a/.github/rules/All Branch Rules.json
+++ b/.github/rules/All Branch Rules.json
@@ -1,0 +1,37 @@
+{
+  "id": 7359757,
+  "name": "All Branch Rules",
+  "target": "branch",
+  "source_type": "Repository",
+  "source": "CenterForOpenScience/angular-osf",
+  "enforcement": "disabled",
+  "conditions": {
+    "ref_name": {
+      "exclude": ["refs/heads/main", "refs/heads/develop"],
+      "include": ["~ALL"]
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "required_review_thread_resolution",
+      "parameters": {
+        "enabled": true
+      }
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
+        "require_last_push_approval": true,
+        "automatic_copilot_code_review_enabled": false,
+        "allowed_merge_methods": ["squash"]
+      }
+    }
+  ],
+  "bypass_actors": []
+}

--- a/.github/rules/Main_Develop Branch Rules.json
+++ b/.github/rules/Main_Develop Branch Rules.json
@@ -1,0 +1,52 @@
+{
+  "id": 7359601,
+  "name": "Main/Develop Branch Rules",
+  "target": "branch",
+  "source_type": "Repository",
+  "source": "CenterForOpenScience/angular-osf",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": ["~DEFAULT_BRANCH", "refs/heads/develop"]
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "merge_queue",
+      "parameters": {
+        "merge_method": "SQUASH",
+        "max_entries_to_build": 8,
+        "min_entries_to_merge": 1,
+        "max_entries_to_merge": 5,
+        "min_entries_to_merge_wait_minutes": 5,
+        "grouping_strategy": "ALLGREEN",
+        "check_response_timeout_minutes": 90
+      }
+    },
+    {
+      "type": "required_review_thread_resolution",
+      "parameters": {
+        "enabled": true
+      }
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
+        "require_last_push_approval": true,
+        "automatic_copilot_code_review_enabled": false,
+        "allowed_merge_methods": ["squash"]
+      }
+    }
+  ],
+  "bypass_actors": []
+}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const {owner, repo} = context.repo;
+            const { owner, repo } = context.repo;
 
             // Determine PR number for both pull_request and pull_request_review events
             let number;
@@ -41,11 +41,13 @@ jobs:
             const latestByUser = new Map();
             for (const r of reviews) latestByUser.set(r.user.id, r.state);
 
-            // Count approvals
             const approvals = [...latestByUser.values()].filter(s => s === 'APPROVED').length;
+            const hasRequestChanges = [...latestByUser.values()].includes('CHANGES_REQUESTED');
 
             if (approvals < 1) {
               core.setFailed(`PR #${number} requires at least one approving review before merging.`);
+            } else if (hasRequestChanges) {
+              core.setFailed(`PR #${number} cannot be merged because at least one reviewer has requested changes.`);
             } else {
               core.info(`Approvals found: ${approvals}. Check passed.`);
             }


### PR DESCRIPTION
I realized there was a gap in the Github actions flow logic that allowed a PR to be merged when there were "changes requested".

This will have no effect on the current Exoft development velocity.

I also downloaded the just settings/rules for a back-up in the repo.
