### PR TITLE
Fix test env SHARE url

### DIFF
--- a/src/environments/environment.test-osf.ts
+++ b/src/environments/environment.test-osf.ts
@@ -5,7 +5,7 @@ export const environment = {
   production: false,
   webUrl: 'https://test.osf.io',
   apiDomainUrl: 'https://api.test.osf.io',
-  shareTroveUrl: 'https://test-share.osf.io/trove',
+  shareTroveUrl: 'https://staging-share.osf.io/trove',
   addonsApiUrl: 'https://addons.test.osf.io/v1',
   funderApiUrl: 'https://api.crossref.org/',
   casUrl: 'https://accounts.test.osf.io',


### PR DESCRIPTION
`test-share.osf.io` does not exist.
All non-production envs use `staging-share.osf.io`