### PR TITLE
fix(datalayer): fixed to handle datalayer existence

### DIFF
--- a/src/app/core/services/help-scout.service.spec.ts
+++ b/src/app/core/services/help-scout.service.spec.ts
@@ -9,57 +9,107 @@ import { UserSelectors } from '@core/store/user/user.selectors';
 import { HelpScoutService } from './help-scout.service';
 
 describe('HelpScoutService', () => {
-  let storeMock: Partial<Store>;
+  const storeMock: Partial<Store> = {
+    selectSignal: jest.fn().mockImplementation((selector) => {
+      if (selector === UserSelectors.isAuthenticated) {
+        return authSignal;
+      }
+      return signal(null); // fallback
+    }),
+  };
   let service: HelpScoutService;
   let mockWindow: any;
   const authSignal = signal(false);
 
-  beforeEach(() => {
-    mockWindow = {
-      dataLayer: {},
-    };
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
 
-    storeMock = {
-      selectSignal: jest.fn().mockImplementation((selector) => {
-        if (selector === UserSelectors.isAuthenticated) {
-          return authSignal;
-        }
-        return signal(null); // fallback
-      }),
-    };
+  describe('initialization - no dataLayer', () => {
+    beforeEach(() => {
+      mockWindow = {};
+      TestBed.configureTestingModule({
+        providers: [
+          { provide: WINDOW, useValue: mockWindow },
+          HelpScoutService,
+          { provide: Store, useValue: storeMock },
+        ],
+      });
 
-    TestBed.configureTestingModule({
-      providers: [{ provide: WINDOW, useValue: mockWindow }, HelpScoutService, { provide: Store, useValue: storeMock }],
+      service = TestBed.inject(HelpScoutService);
     });
 
-    service = TestBed.inject(HelpScoutService);
-  });
+    it('should initialize dataLayer with default values', () => {
+      expect(mockWindow.dataLayer).toEqual({
+        loggedIn: false,
+        resourceType: undefined,
+      });
+    });
 
-  it('should initialize dataLayer with default values', () => {
-    expect(mockWindow.dataLayer).toEqual({
-      loggedIn: false,
-      resourceType: undefined,
+    it('should set the resourceType', () => {
+      service.setResourceType('project');
+      expect(mockWindow.dataLayer.resourceType).toBe('project');
+    });
+
+    it('should unset the resourceType', () => {
+      service.setResourceType('node');
+      service.unsetResourceType();
+      expect(mockWindow.dataLayer.resourceType).toBeUndefined();
+    });
+
+    it('should set loggedIn to true or false', () => {
+      authSignal.set(true);
+      TestBed.flushEffects();
+      expect(mockWindow.dataLayer.loggedIn).toBeTruthy();
+
+      authSignal.set(false);
+      TestBed.flushEffects();
+      expect(mockWindow.dataLayer.loggedIn).toBeFalsy();
     });
   });
 
-  it('should set the resourceType', () => {
-    service.setResourceType('project');
-    expect(mockWindow.dataLayer.resourceType).toBe('project');
-  });
+  describe('initialization - dataLayer', () => {
+    beforeEach(() => {
+      mockWindow = {
+        dataLayer: {},
+      };
+      TestBed.configureTestingModule({
+        providers: [
+          { provide: WINDOW, useValue: mockWindow },
+          HelpScoutService,
+          { provide: Store, useValue: storeMock },
+        ],
+      });
 
-  it('should unset the resourceType', () => {
-    service.setResourceType('node');
-    service.unsetResourceType();
-    expect(mockWindow.dataLayer.resourceType).toBeUndefined();
-  });
+      service = TestBed.inject(HelpScoutService);
+    });
 
-  it('should set loggedIn to true or false', () => {
-    authSignal.set(true);
-    TestBed.flushEffects();
-    expect(mockWindow.dataLayer.loggedIn).toBeTruthy();
+    it('should initialize dataLayer with default values', () => {
+      expect(mockWindow.dataLayer).toEqual({
+        loggedIn: false,
+        resourceType: undefined,
+      });
+    });
 
-    authSignal.set(false);
-    TestBed.flushEffects();
-    expect(mockWindow.dataLayer.loggedIn).toBeFalsy();
+    it('should set the resourceType', () => {
+      service.setResourceType('project');
+      expect(mockWindow.dataLayer.resourceType).toBe('project');
+    });
+
+    it('should unset the resourceType', () => {
+      service.setResourceType('node');
+      service.unsetResourceType();
+      expect(mockWindow.dataLayer.resourceType).toBeUndefined();
+    });
+
+    it('should set loggedIn to true or false', () => {
+      authSignal.set(true);
+      TestBed.flushEffects();
+      expect(mockWindow.dataLayer.loggedIn).toBeTruthy();
+
+      authSignal.set(false);
+      TestBed.flushEffects();
+      expect(mockWindow.dataLayer.loggedIn).toBeFalsy();
+    });
   });
 });

--- a/src/app/core/services/help-scout.service.ts
+++ b/src/app/core/services/help-scout.service.ts
@@ -51,10 +51,15 @@ export class HelpScoutService {
    * - `resourceType`: undefined
    */
   constructor() {
-    this.window.dataLayer = {
-      loggedIn: false,
-      resourceType: undefined,
-    };
+    if (this.window.dataLayer) {
+      this.window.dataLayer.loggedIn = false;
+      this.window.dataLayer.resourceType = undefined;
+    } else {
+      this.window.dataLayer = {
+        loggedIn: false,
+        resourceType: undefined,
+      };
+    }
 
     effect(() => {
       this.window.dataLayer.loggedIn = this.isAuthenticated();


### PR DESCRIPTION
## Purpose

Do not blindly overwrite the dataLayer on instantiation of the help-scout service

## Summary of Changes

Added a condition to prevent the dataLayer from blindly being overwritten.


