### PR TITLE
feat(environment): extended the environment to use config

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -19,8 +19,8 @@ import { provideRouter, withInMemoryScrolling } from '@angular/router';
 
 import { STATES } from '@core/constants';
 import { APPLICATION_INITIALIZATION_PROVIDER } from '@core/factory/application.initialization.factory';
-import { WINDOW, windowFactory } from '@core/factory/window.factory';
 import { SENTRY_PROVIDER } from '@core/factory/sentry.factory';
+import { WINDOW, windowFactory } from '@core/factory/window.factory';
 import { provideTranslation } from '@core/helpers';
 
 import { authInterceptor, errorInterceptor, viewOnlyInterceptor } from './core/interceptors';

--- a/src/app/core/constants/environment.token.ts
+++ b/src/app/core/constants/environment.token.ts
@@ -1,10 +1,31 @@
+/**
+ * Angular InjectionToken providing access to the global environment configuration.
+ *
+ * This token exposes the values defined in the `environment.ts` file as an injectable object
+ * implementing the `EnvironmentModel` interface.
+ *
+ * ⚠️ **Warning:** This token is marked `DO_NOT_USE` to discourage direct usage in services/components.
+ * Prefer using the `ENVIRONMENT` proxy-based token (if available) to allow dynamic mutation in tests or runtime.
+ *
+ */
+
 import { InjectionToken } from '@angular/core';
 
-import { AppEnvironment } from '@shared/models/environment.model';
+import { EnvironmentModel } from '@shared/models/environment.model';
 
 import { environment } from 'src/environments/environment';
 
-export const ENVIRONMENT = new InjectionToken<AppEnvironment>('App Environment', {
+/**
+ * Injection token representing the app's static environment configuration.
+ *
+ * Do not use this directly unless necessary. Prefer the proxy-based `ENVIRONMENT` token for safer access.
+ */
+export const ENVIRONMENT_DO_NO_USE = new InjectionToken<EnvironmentModel>('App Environment', {
   providedIn: 'root',
-  factory: () => environment as AppEnvironment,
+
+  /**
+   * Factory function that returns the raw environment object cast to `EnvironmentModel`.
+   * This is a one-time snapshot of the environment loaded at build time.
+   */
+  factory: () => environment as EnvironmentModel,
 });

--- a/src/app/core/factory/application.initialization.factory.ts
+++ b/src/app/core/factory/application.initialization.factory.ts
@@ -1,7 +1,8 @@
 import { inject, provideAppInitializer } from '@angular/core';
 
-import { ENVIRONMENT } from '@core/constants/environment.token';
 import { OSFConfigService } from '@core/services/osf-config.service';
+
+import { ENVIRONMENT } from './environment.factory';
 
 import * as Sentry from '@sentry/angular';
 import { GoogleTagManagerConfiguration } from 'angular-google-tag-manager';
@@ -23,12 +24,12 @@ export function initializeApplication() {
 
     await configService.load();
 
-    const googleTagManagerId = configService.get('googleTagManagerId');
+    const googleTagManagerId = environment.googleTagManagerId;
     if (googleTagManagerId) {
       googleTagManagerConfiguration.set({ id: googleTagManagerId });
     }
 
-    const dsn = configService.get('sentryDsn');
+    const dsn = environment.sentryDsn;
     if (dsn) {
       // More Options
       // https://docs.sentry.io/platforms/javascript/guides/angular/configuration/options/

--- a/src/app/core/factory/environment.factory.spec.ts
+++ b/src/app/core/factory/environment.factory.spec.ts
@@ -1,0 +1,63 @@
+import { TestBed } from '@angular/core/testing';
+
+import { EnvironmentModel } from '@osf/shared/models/environment.model';
+
+import { ENVIRONMENT } from './environment.factory';
+
+import { OSFTestingModule } from '@testing/osf.testing.module';
+
+describe('Factory: Environment', () => {
+  let environment: EnvironmentModel;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [OSFTestingModule],
+    }).compileComponents();
+
+    environment = TestBed.inject(ENVIRONMENT);
+  });
+
+  it('should allow updating a string value', () => {
+    expect(environment.apiDomainUrl).toBe('http://localhost:8000');
+    environment.apiDomainUrl = 'https://new-api.example.com';
+    expect(environment.apiDomainUrl).toBe('https://new-api.example.com');
+  });
+
+  it('should allow updating a boolean value', () => {
+    expect(environment.production).toBeFalsy();
+    environment.production = true;
+    expect(environment.production).toBeTruthy();
+  });
+
+  it('should allow updating a nullable value', () => {
+    environment.dataciteTrackerRepoId = 'new-repo-id';
+    expect(environment.dataciteTrackerRepoId).toBe('new-repo-id');
+
+    environment.dataciteTrackerRepoId = null;
+    expect(environment.dataciteTrackerRepoId).toBeNull();
+  });
+
+  it('should allow updating an optional nested object', () => {
+    environment.activityLogs = { pageSize: 100 };
+    expect(environment.activityLogs).toEqual({ pageSize: 100 });
+    environment.activityLogs.pageSize = 200;
+    expect(environment.activityLogs).toEqual({ pageSize: 200 });
+    expect(environment.activityLogs.pageSize).toBe(200);
+  });
+
+  it('should reflect changes in subsequent reads', () => {
+    environment.facebookAppId = 'abc123';
+    expect(environment.facebookAppId).toBe('abc123');
+
+    environment.facebookAppId = 'xyz999';
+    expect(environment.facebookAppId).toBe('xyz999');
+  });
+
+  it('should support type-safe key/value updates through keyof', () => {
+    const key: keyof EnvironmentModel = 'supportEmail';
+    const newValue = 'support@newdomain.com';
+
+    environment[key] = newValue;
+    expect(environment.supportEmail).toBe(newValue);
+  });
+});

--- a/src/app/core/factory/environment.factory.ts
+++ b/src/app/core/factory/environment.factory.ts
@@ -1,0 +1,22 @@
+import { inject, InjectionToken } from '@angular/core';
+
+import { ENVIRONMENT_DO_NO_USE } from '@core/constants/environment.token';
+import { EnvironmentModel } from '@osf/shared/models/environment.model';
+
+export const ENVIRONMENT = new InjectionToken<EnvironmentModel>('EnvironmentProxy', {
+  providedIn: 'root',
+  factory: () => {
+    const environment = inject(ENVIRONMENT_DO_NO_USE);
+
+    return new Proxy<EnvironmentModel>(
+      { ...environment },
+      {
+        get: (target, prop: keyof EnvironmentModel) => target[prop],
+        set: <K extends keyof EnvironmentModel>(target: EnvironmentModel, prop: K, value: EnvironmentModel[K]) => {
+          target[prop] = value;
+          return true;
+        },
+      }
+    );
+  },
+});

--- a/src/app/core/services/osf-config.service.spec.ts
+++ b/src/app/core/services/osf-config.service.spec.ts
@@ -1,7 +1,9 @@
 import { HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 
+import { ENVIRONMENT } from '@core/factory/environment.factory';
 import { ConfigModel } from '@core/models/config.model';
+import { EnvironmentModel } from '@osf/shared/models/environment.model';
 
 import { OSFConfigService } from './osf-config.service';
 
@@ -10,12 +12,11 @@ import { OSFTestingModule } from '@testing/osf.testing.module';
 describe('Service: Config', () => {
   let service: OSFConfigService;
   let httpMock: HttpTestingController;
+  let environment: EnvironmentModel;
 
   const mockConfig: ConfigModel = {
-    apiUrl: 'https://api.example.com',
-    environment: 'staging',
-    featureToggle: true,
-    customKey: 'customValue',
+    apiDomainUrl: 'https://api.example.com',
+    production: true,
   } as any; // Cast to any if index signature isn’t added
 
   beforeEach(async () => {
@@ -27,6 +28,7 @@ describe('Service: Config', () => {
 
     service = TestBed.inject(OSFConfigService);
     httpMock = TestBed.inject(HttpTestingController);
+    environment = TestBed.inject(ENVIRONMENT);
   });
 
   it('should return a value with get()', async () => {
@@ -34,11 +36,13 @@ describe('Service: Config', () => {
     const request = httpMock.expectOne('/assets/config/config.json');
     request.flush(mockConfig);
     await loadPromise;
-    expect(service.get('apiUrl')).toBe('https://api.example.com');
-    expect(service.get('featureToggle')).toBe(true);
+    expect(environment.apiDomainUrl).toBe('https://api.example.com');
+    expect(environment.production).toBeTruthy();
     loadPromise = service.load();
     await loadPromise;
-    expect(service.get('nonexistentKey')).toBeNull();
+
+    expect(environment.apiDomainUrl).toBe('https://api.example.com');
+    expect(environment.production).toBeTruthy();
 
     expect(httpMock.verify()).toBeUndefined();
   });
@@ -48,11 +52,13 @@ describe('Service: Config', () => {
     const request = httpMock.expectOne('/assets/config/config.json');
     request.flush(mockConfig);
     await loadPromise;
-    expect(service.has('apiUrl')).toBeTruthy();
-    expect(service.has('featureToggle')).toBeTruthy();
+    expect(environment.apiDomainUrl).toBe('https://api.example.com');
+    expect(environment.production).toBeTruthy();
+
     loadPromise = service.load();
     await loadPromise;
-    expect(service.has('nonexistentKey')).toBeFalsy();
+    expect(environment.apiDomainUrl).toBe('https://api.example.com');
+    expect(environment.production).toBeTruthy();
 
     expect(httpMock.verify()).toBeUndefined();
   });

--- a/src/app/core/services/osf-config.service.ts
+++ b/src/app/core/services/osf-config.service.ts
@@ -3,6 +3,7 @@ import { catchError, lastValueFrom, of, shareReplay } from 'rxjs';
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 
+import { ENVIRONMENT } from '@core/factory/environment.factory';
 import { ConfigModel } from '@core/models/config.model';
 
 /**
@@ -23,6 +24,8 @@ export class OSFConfigService {
    */
   private http: HttpClient = inject(HttpClient);
 
+  private environment = inject(ENVIRONMENT);
+
   /**
    * Stores the loaded configuration object after it is fetched from the server.
    * Remains `null` until `load()` is successfully called.
@@ -41,35 +44,13 @@ export class OSFConfigService {
           catchError(() => of({} as ConfigModel))
         )
       );
+
+      // Apply every key from config to environment
+      for (const [key, value] of Object.entries(this.config)) {
+        // eslint-disable-next-line
+        // @ts-ignore
+        this.environment[key] = value;
+      }
     }
-  }
-
-  /**
-   * Retrieves a configuration value by key after ensuring the config is loaded.
-   * @param key The key to look up in the config.
-   * @returns The value of the configuration key.
-   */
-  get<T extends keyof ConfigModel>(key: T): ConfigModel[T] | null {
-    return this.config?.[key] || null;
-  }
-
-  /**
-   * Checks whether a specific configuration key exists and has a truthy value.
-   *
-   * This method inspects the currently loaded configuration object and determines
-   * if the given key is present and evaluates to a truthy value (e.g., non-null, non-undefined, not false/0/empty string).
-   *
-   * @template T - A key of the `ConfigModel` interface.
-   * @param {T} key - The key to check within the configuration object.
-   * @returns {boolean} - Returns `true` if the key exists and its value is truthy; otherwise, returns `false`.
-   *
-   * @example
-   * if (configService.has('sentryDsn')) {
-   *   const dsn = configService.get('sentryDsn');
-   *   Sentry.init({ dsn });
-   * }
-   */
-  has<T extends keyof ConfigModel>(key: T): boolean {
-    return this.config?.[key] ? true : false;
   }
 }

--- a/src/app/features/registry/pages/registration-recent-activity/registration-recent-activity.component.ts
+++ b/src/app/features/registry/pages/registration-recent-activity/registration-recent-activity.component.ts
@@ -9,7 +9,7 @@ import { DatePipe } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, inject, OnDestroy, signal } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 
-import { ENVIRONMENT } from '@core/constants/environment.token';
+import { ENVIRONMENT } from '@core/factory/environment.factory';
 import { CustomPaginatorComponent } from '@shared/components';
 import { ACTIVITY_LOGS_DEFAULT_PAGE_SIZE } from '@shared/constants/activity-logs';
 import {

--- a/src/app/shared/models/environment.model.ts
+++ b/src/app/shared/models/environment.model.ts
@@ -1,10 +1,9 @@
-export interface AppEnvironment {
+export interface EnvironmentModel {
   production: boolean;
   webUrl: string;
   apiDomainUrl: string;
   shareTroveUrl: string;
   addonsApiUrl: string;
-  fileApiUrl: string;
   funderApiUrl: string;
   casUrl: string;
   recaptchaSiteKey: string;
@@ -18,4 +17,36 @@ export interface AppEnvironment {
   activityLogs?: {
     pageSize?: number;
   };
+
+  /**
+   * The DSN (Data Source Name) used to configure Sentry for error tracking.
+   * This string is provided by Sentry and uniquely identifies your project.
+   *
+   * @example "https://1234567890abcdef.ingest.sentry.io/1234567"
+   */
+  sentryDsn: string;
+
+  /**
+   * The Google Tag Manager ID used to embed GTM scripts for analytics tracking.
+   * This ID typically starts with "GTM-".
+   *
+   * @example "GTM-ABCDE123"
+   */
+  googleTagManagerId: string;
+
+  /**
+   * API Key used to load the Google Picker API.
+   * This key should be restricted in the Google Cloud Console to limit usage.
+   *
+   * @example "AIzaSyA...your_api_key"
+   */
+  googleFilePickerApiKey: string;
+
+  /**
+   * Google Cloud Project App ID used by the Google Picker SDK.
+   * This numeric ID identifies your Google project and is required for some configurations.
+   *
+   * @example 123456789012
+   */
+  googleFilePickerAppId: number;
 }

--- a/src/app/shared/services/datacite/datacite.service.spec.ts
+++ b/src/app/shared/services/datacite/datacite.service.spec.ts
@@ -4,7 +4,7 @@ import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 
-import { ENVIRONMENT } from '@core/constants/environment.token';
+import { ENVIRONMENT } from '@core/factory/environment.factory';
 import { Identifier } from '@shared/models';
 import { DataciteEvent } from '@shared/models/datacite/datacite-event.enum';
 

--- a/src/app/shared/services/datacite/datacite.service.ts
+++ b/src/app/shared/services/datacite/datacite.service.ts
@@ -3,7 +3,7 @@ import { EMPTY, filter, map, Observable, of, switchMap, take } from 'rxjs';
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 
-import { ENVIRONMENT } from '@core/constants/environment.token';
+import { ENVIRONMENT } from '@core/factory/environment.factory';
 import { Identifier } from '@shared/models';
 import { DataciteEvent } from '@shared/models/datacite/datacite-event.enum';
 import { IdentifiersJsonApiResponse } from '@shared/models/identifiers/identifier-json-api.model';
@@ -12,8 +12,8 @@ import { IdentifiersJsonApiResponse } from '@shared/models/identifiers/identifie
   providedIn: 'root',
 })
 export class DataciteService {
-  #http: HttpClient = inject(HttpClient);
-  #environment = inject(ENVIRONMENT);
+  private http: HttpClient = inject(HttpClient);
+  private environment = inject(ENVIRONMENT);
 
   logIdentifiableView(trackable: Observable<{ identifiers?: Identifier[] } | null>) {
     return this.watchIdentifiable(trackable, DataciteEvent.VIEW);
@@ -45,8 +45,8 @@ export class DataciteService {
   }
 
   private logFile(targetId: string, targetType: string, event: DataciteEvent): Observable<void> {
-    const url = `${this.#environment.webUrl}/${targetType}/${targetId}/identifiers`;
-    return this.#http.get<IdentifiersJsonApiResponse>(url).pipe(
+    const url = `${this.environment.webUrl}/${targetType}/${targetId}/identifiers`;
+    return this.http.get<IdentifiersJsonApiResponse>(url).pipe(
       map((item) => ({
         identifiers: item.data.map<Identifier>((identifierData) => ({
           id: identifierData.id,
@@ -68,19 +68,19 @@ export class DataciteService {
    *          or EMPTY if DOI or repo ID is missing.
    */
   private logActivity(event: DataciteEvent, doi: string): Observable<void> {
-    if (!doi || !this.#environment.dataciteTrackerRepoId) {
+    if (!doi || !this.environment.dataciteTrackerRepoId) {
       return EMPTY;
     }
     const payload = {
       n: event,
       u: window.location.href,
-      i: this.#environment.dataciteTrackerRepoId,
+      i: this.environment.dataciteTrackerRepoId,
       p: doi,
     };
     const headers = {
       'Content-Type': 'application/json',
     };
-    return this.#http.post(this.#environment.dataciteTrackerAddress, payload, { headers }).pipe(
+    return this.http.post(this.environment.dataciteTrackerAddress, payload, { headers }).pipe(
       map(() => {
         return;
       })

--- a/src/environments/environment.local.ts
+++ b/src/environments/environment.local.ts
@@ -4,7 +4,6 @@ export const environment = {
   apiDomainUrl: 'http://localhost:8000',
   shareTroveUrl: 'https://localhost:8003/trove',
   addonsApiUrl: 'http://localhost:8004/v1',
-  fileApiUrl: 'http://localhost:7777/v1',
   funderApiUrl: 'https://api.crossref.org/',
   casUrl: 'http://localhost:8080',
   recaptchaSiteKey: '6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI',

--- a/src/testing/mocks/environment.token.mock.ts
+++ b/src/testing/mocks/environment.token.mock.ts
@@ -1,4 +1,4 @@
-import { ENVIRONMENT } from '@core/constants/environment.token';
+import { ENVIRONMENT_DO_NO_USE } from '@core/constants/environment.token';
 
 /**
  * Mock provider for Angular's `ENVIRONMENT_INITIALIZER` token used in unit tests.
@@ -21,8 +21,9 @@ import { ENVIRONMENT } from '@core/constants/environment.token';
  * ```
  */
 export const EnvironmentTokenMock = {
-  provide: ENVIRONMENT,
+  provide: ENVIRONMENT_DO_NO_USE,
   useValue: {
     production: false,
+    apiDomainUrl: 'http://localhost:8000',
   },
 };


### PR DESCRIPTION
## Purpose

Allow usage of config.json until the cloud team can fix the deploy process

## Summary of Changes

Created a factory for environment that is updated by config.json if it exists.

The only refactor (if I did it right) should be

```
import { environment } from 'src/environments/environment';
```

to 
```
private readonly environment = inject(ENVIRONMENT)
```