### PR TITLE
fix(addons): fix icon display issue, use gravyvalet icon

### DIFF
--- a/src/app/shared/components/addons/addon-card/addon-card.component.html
+++ b/src/app/shared/components/addons/addon-card/addon-card.component.html
@@ -1,12 +1,7 @@
 <div class="addon-card flex flex-1 gap-4 flex-column p-5">
   <div class="max-h-8rem flex justify-content-center align-items-center">
-    @if (actualAddon()?.externalServiceName) {
-      <img
-        class="addon-image"
-        alt="Addon card image"
-        [src]="'assets/icons/addons/' + actualAddon()!.externalServiceName + '.svg'"
-        data-test-addon-card-logo
-      />
+    @if (actualAddon()?.iconUrl) {
+      <img class="addon-image" alt="Addon card image" [src]="actualAddon()!.iconUrl" data-test-addon-card-logo />
     }
   </div>
 

--- a/src/app/shared/mappers/addon.mapper.ts
+++ b/src/app/shared/mappers/addon.mapper.ts
@@ -25,6 +25,7 @@ export class AddonMapper {
       supportedResourceTypes: response.attributes.supported_resource_types,
       credentialsFormat: response.attributes.credentials_format,
       providerName: response.attributes.display_name,
+      iconUrl: response.attributes.icon_url,
     };
   }
 

--- a/src/app/shared/mocks/addon.mock.ts
+++ b/src/app/shared/mocks/addon.mock.ts
@@ -11,4 +11,5 @@ export const MOCK_ADDON: AddonModel = {
   credentialsFormat: CredentialsFormat.ACCESS_SECRET_KEYS,
   providerName: 'Test Provider',
   wbKey: 'github',
+  iconUrl: 'https://test.com/icon.png',
 };

--- a/src/app/shared/models/addons/addons.models.ts
+++ b/src/app/shared/models/addons/addons.models.ts
@@ -9,6 +9,7 @@ export interface AddonGetResponseJsonApi {
     external_service_name: string;
     credentials_format: string;
     wb_key: string;
+    icon_url: string;
     [key: string]: unknown;
   };
   relationships: {
@@ -103,6 +104,7 @@ export interface AddonModel {
   credentialsFormat: string;
   providerName: string;
   wbKey: string;
+  iconUrl: string;
 }
 
 export interface IncludedAddonData {

--- a/src/app/shared/models/addons/authorized-account.model.ts
+++ b/src/app/shared/models/addons/authorized-account.model.ts
@@ -15,4 +15,5 @@ export interface AuthorizedAccountModel {
   supportedFeatures: string[];
   providerName: string;
   credentialsFormat: string;
+  iconUrl?: string;
 }

--- a/src/app/shared/models/addons/configured-addon.model.ts
+++ b/src/app/shared/models/addons/configured-addon.model.ts
@@ -13,4 +13,5 @@ export interface ConfiguredAddonModel {
   baseAccountType: string;
   externalStorageServiceId?: string;
   rootFolderId?: string;
+  iconUrl?: string;
 }


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the correct branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `feat(ENG-123): some really great stuff`
-->

- Ticket: []
- Feature flag: n/a

## Purpose

<!-- Describe the purpose of your changes. -->
This pull request updates the addon card component to use the icon_url returned by gravyvalet for displaying addon icons. This ensures consistent and correct icon display for all addons.

## Summary of Changes

<!-- Briefly describe or list your changes. -->

## Screenshot(s)

<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
