### PR TITLE
[ENG-9074] fix(Add Community Metadata Button ): fix Add Community Metadata Button – Incorrect Visibility

### DIFF
--- a/src/app/features/files/pages/file-detail/file-detail.component.html
+++ b/src/app/features/files/pages/file-detail/file-detail.component.html
@@ -23,7 +23,7 @@
     </div>
 
     <div class="flex gap-3 ml-auto sm-round-padding-btn">
-      @if (!isAnonymous() && !hasViewOnly()) {
+      @if (!isAnonymous() && !hasViewOnly() && canManageFiles()) {
         <p-button
           severity="secondary"
           [label]="'files.detail.actions.addCommunityMetadata' | translate"

--- a/src/app/features/files/pages/file-detail/file-detail.component.ts
+++ b/src/app/features/files/pages/file-detail/file-detail.component.ts
@@ -136,8 +136,11 @@ export class FileDetailComponent {
   fileRevisions = select(FilesSelectors.getFileRevisions);
   isFileRevisionLoading = select(FilesSelectors.isFileRevisionsLoading);
   hasWriteAccess = select(FilesSelectors.hasWriteAccess);
-
+  hasAdminAccess = select(FilesSelectors.hasAdminAccess);
   hasViewOnly = computed(() => hasViewOnlyParam(this.router));
+  canManageFiles = computed(() => {
+    return this.hasWriteAccess() || this.hasAdminAccess();
+  });
 
   safeLink: SafeResourceUrl | null = null;
   resourceId = '';

--- a/src/app/features/files/store/files.selectors.ts
+++ b/src/app/features/files/store/files.selectors.ts
@@ -148,4 +148,9 @@ export class FilesSelectors {
   static hasWriteAccess(state: FilesStateModel): boolean {
     return state.openedFile.data?.target?.currentUserPermissions?.includes(UserPermissions.Write) || false;
   }
+
+  @Selector([FilesState])
+  static hasAdminAccess(state: FilesStateModel): boolean {
+    return state.openedFile.data?.target?.currentUserPermissions?.includes(UserPermissions.Admin) || false;
+  }
 }


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the correct branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `feat(ENG-123): some really great stuff`
-->

- Ticket: https://openscience.atlassian.net/browse/ENG-9074
- Feature flag: n/a

## Purpose

Summary

The “Add Community Metadata” button is visible to all users, including unauthenticated visitors. This button should only display for contributors with write or admin permissions on a project.


Description

Currently, the “Add Community Metadata” button appears on project file pages even when the user is not logged in or lacks sufficient permissions.
This violates the intended access rules, where only write and admin contributors should see or interact with this button.

Observed Behavior:

The button is visible to unauthenticated users.

Clicking the button as a non-contributor leads to unintended UI exposure.

Expected Behavior:

The button should only render for authenticated users with write or admin contributor permissions.

The button should not appear for read-only contributors or non-contributors  (The project must be public).


## Summary of Changes

Check if user has write or admin access before rendering the button


https://github.com/user-attachments/assets/7bd4b666-103e-40ae-bd22-84a653915376

## Screenshot(s)
<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

Navigate to https://test.osf.io/9e4zc/files/3xktc or staging4 (if it does not work for test.osf.io maybe it does not deploy at same time ) while not logged in.

Observe that the “Add Community Metadata” button is visible.

Log in as a read-only contributor — note that the button is still visible.

Log in as a write/admin contributor — the button functions correctly.
