### PR TITLE
[ANG-910] fix(account merge modal): Accounts: when merging accounts, wrong modal showing

### DIFF
--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -388,9 +388,9 @@
       }
     },
     "confirmEmail": {
-      "title": "Add alternative email",
-      "description": "Do you want to add ",
-      "description2": "to your profile ?",
+      "title": "Merge account",
+      "description": "Would you like to merge ",
+      "description2": "into your account? This action is irreversible.",
       "goToEmails": "Add email",
       "emailNotAdded": "{{name}} has not been added to your account.",
       "emailVerified": "{{name}} has been added to your account."


### PR DESCRIPTION
- Ticket: https://openscience.atlassian.net/browse/ANG-910
- Feature flag: n/a

## Purpose

Steps: have two accounts on test (primary, and secondary). Follow the steps to merge your secondary account into your primary, by adding your secondary accounts email address to your primary account as an ‘alternate email’. from your secondary email inbox, click the confirmation link.

Expected: I expect a warning that my account will be merged and this is irreversible. “Would you like to merge <email> into your account? This action is irreversible.”

## Summary of Changes

  Updated en.json merge modal text
  
## Screenshot(s)

<img width="1568" height="878" alt="image" src="https://github.com/user-attachments/assets/c77b58fa-49d6-44f4-997b-7facf590087c" />

<img width="905" height="678" alt="image" src="https://github.com/user-attachments/assets/1dd77a04-002f-4871-9c39-9b3efef1f21c" />

after approval of account that is needed to be merged on main account we see warning text

<img width="1570" height="1192" alt="image" src="https://github.com/user-attachments/assets/0613e7db-630e-4541-a0ca-80508b449797" />


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
