### PR TITLE
[ENG-10383] fix: Navigating to the old /discover URL format should redirect to the current registry page

### DIFF
--- a/src/app/features/registries/registries.routes.ts
+++ b/src/app/features/registries/registries.routes.ts
@@ -49,10 +49,8 @@ export const registriesRoutes: Routes = [
       },
       {
         path: ':providerId',
-        loadComponent: () =>
-          import('@osf/features/registries/pages/registries-provider-search/registries-provider-search.component').then(
-            (c) => c.RegistriesProviderSearchComponent
-          ),
+        redirectTo: ':providerId/discover',
+        pathMatch: 'full',
       },
       {
         path: ':providerId/discover',

--- a/src/app/features/registries/registries.routes.ts
+++ b/src/app/features/registries/registries.routes.ts
@@ -55,6 +55,13 @@ export const registriesRoutes: Routes = [
           ),
       },
       {
+        path: ':providerId/discover',
+        loadComponent: () =>
+          import('@osf/features/registries/pages/registries-provider-search/registries-provider-search.component').then(
+            (c) => c.RegistriesProviderSearchComponent
+          ),
+      },
+      {
         path: ':providerId/moderation',
         canActivate: [authGuard, registrationModerationGuard],
         loadChildren: () =>


### PR DESCRIPTION


<!--
  Before you submit your Pull Request, make sure you picked the correct branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `feat(ENG-123): some really great stuff`
-->

- Ticket: https://openscience.atlassian.net/browse/ENG-10383
- Feature flag: n/a

## Purpose

Navigating to the old /discover URL format should redirect to the current registry page.

https://osf.io/registries/dataarchive/discover and https://osf.io/registries/dataarchive/  


## Summary of Changes

add to registrations router mapping for providerId/discover

https://github.com/user-attachments/assets/1c5b4920-dbd8-4318-af7d-153dba1e2444


## Screenshot(s)

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
