### PR TITLE
fix(ENG-9810): wire up provider subscription notification settings

### DIFF
--- a/src/app/features/moderation/collection-moderation.routes.ts
+++ b/src/app/features/moderation/collection-moderation.routes.ts
@@ -8,6 +8,7 @@ import { ActivityLogsState } from '@shared/stores/activity-logs';
 import { CollectionsState } from '@shared/stores/collections';
 
 import { ModeratorsState } from './store/moderators';
+import { ProviderSubscriptionsState } from './store/provider-subscriptions';
 import { CollectionModerationTab } from './enums';
 
 export const collectionModerationRoutes: Routes = [
@@ -46,7 +47,8 @@ export const collectionModerationRoutes: Routes = [
           import('./components/notification-settings/notification-settings.component').then(
             (m) => m.NotificationSettingsComponent
           ),
-        data: { tab: CollectionModerationTab.Settings },
+        data: { tab: CollectionModerationTab.Settings, resourceType: ResourceType.Collection },
+        providers: [provideStates([ProviderSubscriptionsState])],
       },
     ],
   },

--- a/src/app/features/moderation/collection-moderation.routes.ts
+++ b/src/app/features/moderation/collection-moderation.routes.ts
@@ -3,7 +3,7 @@ import { provideStates } from '@ngxs/store';
 import { Routes } from '@angular/router';
 
 import { CollectionsModerationState } from '@osf/features/moderation/store/collections-moderation';
-import { ResourceType } from '@osf/shared/enums/resource-type.enum';
+import { CurrentResourceType, ResourceType } from '@osf/shared/enums/resource-type.enum';
 import { ActivityLogsState } from '@shared/stores/activity-logs';
 import { CollectionsState } from '@shared/stores/collections';
 
@@ -47,7 +47,7 @@ export const collectionModerationRoutes: Routes = [
           import('./components/notification-settings/notification-settings.component').then(
             (m) => m.NotificationSettingsComponent
           ),
-        data: { tab: CollectionModerationTab.Settings, resourceType: ResourceType.Collection },
+        data: { tab: CollectionModerationTab.Settings, resourceType: CurrentResourceType.Collections },
         providers: [provideStates([ProviderSubscriptionsState])],
       },
     ],

--- a/src/app/features/moderation/components/notification-settings/notification-settings.component.html
+++ b/src/app/features/moderation/components/notification-settings/notification-settings.component.html
@@ -1,6 +1,30 @@
+<h2>{{ 'moderation.notificationPreferences.title' | translate }}</h2>
 <p>
-  <span>{{ 'moderation.settingsMessage' | translate }}</span>
+  <span>{{ 'moderation.notificationPreferences.note' | translate }}</span>
   <a class="ml-1 font-bold cursor-pointer" routerLink="/settings/notifications">
     {{ 'moderation.userSettings' | translate }}
   </a>
 </p>
+
+@if (!isLoading()) {
+  <section class="notification-configuration" [formGroup]="form">
+    @for (sub of subscriptions(); track sub.id) {
+      <p>{{ labelKey(sub.event) | translate }}</p>
+      <p-select
+        [formControlName]="sub.id"
+        class="dropdown"
+        [options]="frequencyOptions"
+        optionLabel="label"
+        optionValue="value"
+        (onChange)="onFrequencyChange(sub, $event.value)"
+      />
+    }
+  </section>
+} @else {
+  <section class="notification-configuration">
+    @for (_ of [1, 2]; track $index) {
+      <p-skeleton width="20rem" height="2rem"></p-skeleton>
+      <p-skeleton class="dropdown" height="3rem"></p-skeleton>
+    }
+  </section>
+}

--- a/src/app/features/moderation/components/notification-settings/notification-settings.component.html
+++ b/src/app/features/moderation/components/notification-settings/notification-settings.component.html
@@ -1,23 +1,35 @@
 <h2>{{ 'moderation.notificationPreferences.title' | translate }}</h2>
-<p>
+<p class="mt-4">
   <span>{{ 'moderation.notificationPreferences.note' | translate }}</span>
-  <a class="ml-1 font-bold cursor-pointer" routerLink="/settings/notifications">
+  <a class="ml-1 font-bold" routerLink="/settings/notifications">
     {{ 'moderation.userSettings' | translate }}
   </a>
 </p>
 
 @if (!isLoading()) {
-  <section class="notification-configuration" [formGroup]="form">
+  <section class="notification-configuration mt-4" [formGroup]="form">
     @for (sub of subscriptions(); track sub.id) {
-      <p>{{ labelKey(sub.event) | translate }}</p>
+      <label [for]="'subscription-' + sub.id">
+        {{ 'moderation.notificationPreferences.items.' + sub.event | translate }}
+      </label>
+
       <p-select
+        [inputId]="'subscription-' + sub.id"
         [formControlName]="sub.id"
         class="dropdown"
         [options]="frequencyOptions"
         optionLabel="label"
         optionValue="value"
         (onChange)="onFrequencyChange(sub, $event.value)"
-      />
+      >
+        <ng-template #selectedItem let-selectedOption>
+          {{ selectedOption.label | translate }}
+        </ng-template>
+
+        <ng-template #item let-item>
+          {{ item.label | translate }}
+        </ng-template>
+      </p-select>
     }
   </section>
 } @else {

--- a/src/app/features/moderation/components/notification-settings/notification-settings.component.scss
+++ b/src/app/features/moderation/components/notification-settings/notification-settings.component.scss
@@ -1,0 +1,20 @@
+@use "styles/variables" as var;
+
+.notification-configuration {
+  display: grid;
+  grid-gap: 12px;
+  align-items: center;
+  grid-template-columns: 0.5fr 2fr;
+  .dropdown {
+    width: 50%;
+  }
+
+  @media (max-width: var.$breakpoint-sm) {
+    grid-template-columns: 1fr;
+    grid-row-gap: 0;
+
+    .dropdown {
+      width: 100%;
+    }
+  }
+}

--- a/src/app/features/moderation/components/notification-settings/notification-settings.component.scss
+++ b/src/app/features/moderation/components/notification-settings/notification-settings.component.scss
@@ -2,16 +2,17 @@
 
 .notification-configuration {
   display: grid;
-  grid-gap: 12px;
+  gap: 12px;
   align-items: center;
   grid-template-columns: 0.5fr 2fr;
+
   .dropdown {
     width: 50%;
   }
 
   @media (max-width: var.$breakpoint-sm) {
     grid-template-columns: 1fr;
-    grid-row-gap: 0;
+    row-gap: 0;
 
     .dropdown {
       width: 100%;

--- a/src/app/features/moderation/components/notification-settings/notification-settings.component.spec.ts
+++ b/src/app/features/moderation/components/notification-settings/notification-settings.component.spec.ts
@@ -1,17 +1,22 @@
-import { MockProvider } from 'ng-mocks';
+import { Store } from '@ngxs/store';
 
-import { of } from 'rxjs';
+import { MockProvider } from 'ng-mocks';
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
 
-import { ResourceType } from '@osf/shared/enums/resource-type.enum';
+import { SUBSCRIPTION_FREQUENCY_OPTIONS } from '@osf/shared/constants/subscription-options.const';
+import { CurrentResourceType } from '@osf/shared/enums/resource-type.enum';
 import { SubscriptionEvent } from '@osf/shared/enums/subscriptions/subscription-event.enum';
 import { SubscriptionFrequency } from '@osf/shared/enums/subscriptions/subscription-frequency.enum';
 import { NotificationSubscription } from '@osf/shared/models/notifications/notification-subscription.model';
 import { ToastService } from '@osf/shared/services/toast.service';
 
-import { ProviderSubscriptionsSelectors } from '../../store/provider-subscriptions';
+import {
+  GetProviderSubscriptions,
+  ProviderSubscriptionsSelectors,
+  UpdateProviderSubscription,
+} from '../../store/provider-subscriptions';
 
 import { NotificationSettingsComponent } from './notification-settings.component';
 
@@ -33,7 +38,7 @@ const MOCK_PROVIDER_SUBSCRIPTIONS: NotificationSubscription[] = [
   },
 ];
 
-async function createComponent(resourceType: ResourceType, providerId = 'test-provider-123') {
+async function createComponent(resourceType: CurrentResourceType, providerId = 'test-provider-123') {
   const mockActivatedRoute = ActivatedRouteMockBuilder.create()
     .withParams({ providerId })
     .withData({ resourceType })
@@ -56,19 +61,24 @@ async function createComponent(resourceType: ResourceType, providerId = 'test-pr
   const fixture = TestBed.createComponent(NotificationSettingsComponent);
   const component = fixture.componentInstance;
   const toastService = TestBed.inject(ToastService) as jest.Mocked<ToastService>;
+  const store = TestBed.inject(Store);
 
-  return { fixture, component, toastService };
+  return { fixture, component, toastService, store };
 }
 
 describe('NotificationSettingsComponent', () => {
   let component: NotificationSettingsComponent;
   let fixture: ComponentFixture<NotificationSettingsComponent>;
   let toastService: jest.Mocked<ToastService>;
+  let store: Store;
 
   const mockProviderId = 'test-provider-123';
 
   beforeEach(async () => {
-    ({ fixture, component, toastService } = await createComponent(ResourceType.Preprint, mockProviderId));
+    ({ fixture, component, toastService, store } = await createComponent(
+      CurrentResourceType.Preprints,
+      mockProviderId
+    ));
   });
 
   it('should create', () => {
@@ -79,49 +89,42 @@ describe('NotificationSettingsComponent', () => {
   it('should read providerId and resourceType from route', () => {
     fixture.detectChanges();
     expect(component.providerId()).toBe(mockProviderId);
-    expect(component.resourceType()).toBe(ResourceType.Preprint);
-  });
-
-  it('should compute providerType as preprints for ResourceType.Preprint', () => {
-    fixture.detectChanges();
-    expect(component.providerType()).toBe('preprints');
+    expect(component.resourceType()).toBe(CurrentResourceType.Preprints);
   });
 
   it('should dispatch GetProviderSubscriptions on init', () => {
-    const getProviderSubscriptionsSpy = jest.fn().mockReturnValue(of({}));
-    component.actions = { ...component.actions, getProviderSubscriptions: getProviderSubscriptionsSpy };
-
-    component.ngOnInit();
-
-    expect(getProviderSubscriptionsSpy).toHaveBeenCalledWith('preprints', mockProviderId);
-  });
-
-  it('should return correct labelKey for a subscription event', () => {
-    expect(component.labelKey(SubscriptionEvent.ProviderNewPendingSubmissions)).toBe(
-      'moderation.notificationPreferences.items.provider_new_pending_submissions'
+    fixture.detectChanges();
+    expect(store.dispatch as jest.Mock).toHaveBeenCalledWith(
+      new GetProviderSubscriptions(CurrentResourceType.Preprints, mockProviderId)
     );
   });
 
   it('should dispatch UpdateProviderSubscription and show toast on frequency change', () => {
     fixture.detectChanges();
-    const updateSpy = jest.fn().mockReturnValue(of({}));
-    component.actions = { ...component.actions, updateProviderSubscription: updateSpy };
 
     component.onFrequencyChange(MOCK_PROVIDER_SUBSCRIPTIONS[0], SubscriptionFrequency.Daily);
 
-    expect(updateSpy).toHaveBeenCalledWith({
-      providerType: 'preprints',
-      providerId: mockProviderId,
-      subscriptionId: 'sub-1',
-      frequency: SubscriptionFrequency.Daily,
-    });
+    expect(store.dispatch as jest.Mock).toHaveBeenCalledWith(
+      new UpdateProviderSubscription({
+        providerType: CurrentResourceType.Preprints,
+        providerId: mockProviderId,
+        subscriptionId: 'sub-1',
+        frequency: SubscriptionFrequency.Daily,
+      })
+    );
     expect(toastService.showSuccess).toHaveBeenCalledWith('moderation.notificationPreferences.successUpdate');
   });
 
-  it('should build frequencyOptions from SubscriptionFrequency enum', () => {
-    expect(component.frequencyOptions).toEqual(
-      Object.entries(SubscriptionFrequency).map(([key, value]) => ({ label: key, value }))
-    );
+  it('should not dispatch UpdateProviderSubscription if frequency is unchanged', () => {
+    fixture.detectChanges();
+
+    component.onFrequencyChange(MOCK_PROVIDER_SUBSCRIPTIONS[0], SubscriptionFrequency.Instant);
+
+    expect(store.dispatch as jest.Mock).not.toHaveBeenCalledWith(expect.any(UpdateProviderSubscription));
+  });
+
+  it('should expose frequencyOptions from SUBSCRIPTION_FREQUENCY_OPTIONS', () => {
+    expect(component.frequencyOptions).toEqual(SUBSCRIPTION_FREQUENCY_OPTIONS);
   });
 
   it('should populate form controls when subscriptions load', () => {
@@ -130,11 +133,5 @@ describe('NotificationSettingsComponent', () => {
     expect(component.form.contains('sub-2')).toBe(true);
     expect(component.form.get('sub-1')?.value).toBe(SubscriptionFrequency.Instant);
     expect(component.form.get('sub-2')?.value).toBe(SubscriptionFrequency.Never);
-  });
-
-  it('should have actions defined', () => {
-    expect(component.actions).toBeDefined();
-    expect(component.actions.getProviderSubscriptions).toBeDefined();
-    expect(component.actions.updateProviderSubscription).toBeDefined();
   });
 });

--- a/src/app/features/moderation/components/notification-settings/notification-settings.component.spec.ts
+++ b/src/app/features/moderation/components/notification-settings/notification-settings.component.spec.ts
@@ -1,24 +1,140 @@
+import { MockProvider } from 'ng-mocks';
+
+import { of } from 'rxjs';
+
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+
+import { ResourceType } from '@osf/shared/enums/resource-type.enum';
+import { SubscriptionEvent } from '@osf/shared/enums/subscriptions/subscription-event.enum';
+import { SubscriptionFrequency } from '@osf/shared/enums/subscriptions/subscription-frequency.enum';
+import { NotificationSubscription } from '@osf/shared/models/notifications/notification-subscription.model';
+import { ToastService } from '@osf/shared/services/toast.service';
+
+import { ProviderSubscriptionsSelectors } from '../../store/provider-subscriptions';
 
 import { NotificationSettingsComponent } from './notification-settings.component';
 
+import { ToastServiceMock } from '@testing/mocks/toast.service.mock';
 import { OSFTestingModule } from '@testing/osf.testing.module';
+import { ActivatedRouteMockBuilder } from '@testing/providers/route-provider.mock';
+import { provideMockStore } from '@testing/providers/store-provider.mock';
+
+const MOCK_PROVIDER_SUBSCRIPTIONS: NotificationSubscription[] = [
+  {
+    id: 'sub-1',
+    event: SubscriptionEvent.ProviderNewPendingSubmissions,
+    frequency: SubscriptionFrequency.Instant,
+  },
+  {
+    id: 'sub-2',
+    event: SubscriptionEvent.ProviderNewPendingWithdrawRequests,
+    frequency: SubscriptionFrequency.Never,
+  },
+];
+
+async function createComponent(resourceType: ResourceType, providerId = 'test-provider-123') {
+  const mockActivatedRoute = ActivatedRouteMockBuilder.create()
+    .withParams({ providerId })
+    .withData({ resourceType })
+    .build();
+
+  await TestBed.configureTestingModule({
+    imports: [NotificationSettingsComponent, OSFTestingModule],
+    providers: [
+      MockProvider(ActivatedRoute, mockActivatedRoute),
+      ToastServiceMock,
+      provideMockStore({
+        signals: [
+          { selector: ProviderSubscriptionsSelectors.getSubscriptions, value: MOCK_PROVIDER_SUBSCRIPTIONS },
+          { selector: ProviderSubscriptionsSelectors.isLoading, value: false },
+        ],
+      }),
+    ],
+  }).compileComponents();
+
+  const fixture = TestBed.createComponent(NotificationSettingsComponent);
+  const component = fixture.componentInstance;
+  const toastService = TestBed.inject(ToastService) as jest.Mocked<ToastService>;
+
+  return { fixture, component, toastService };
+}
 
 describe('NotificationSettingsComponent', () => {
   let component: NotificationSettingsComponent;
   let fixture: ComponentFixture<NotificationSettingsComponent>;
+  let toastService: jest.Mocked<ToastService>;
+
+  const mockProviderId = 'test-provider-123';
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [NotificationSettingsComponent, OSFTestingModule],
-    }).compileComponents();
-
-    fixture = TestBed.createComponent(NotificationSettingsComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+    ({ fixture, component, toastService } = await createComponent(ResourceType.Preprint, mockProviderId));
   });
 
   it('should create', () => {
+    fixture.detectChanges();
     expect(component).toBeTruthy();
+  });
+
+  it('should read providerId and resourceType from route', () => {
+    fixture.detectChanges();
+    expect(component.providerId()).toBe(mockProviderId);
+    expect(component.resourceType()).toBe(ResourceType.Preprint);
+  });
+
+  it('should compute providerType as preprints for ResourceType.Preprint', () => {
+    fixture.detectChanges();
+    expect(component.providerType()).toBe('preprints');
+  });
+
+  it('should dispatch GetProviderSubscriptions on init', () => {
+    const getProviderSubscriptionsSpy = jest.fn().mockReturnValue(of({}));
+    component.actions = { ...component.actions, getProviderSubscriptions: getProviderSubscriptionsSpy };
+
+    component.ngOnInit();
+
+    expect(getProviderSubscriptionsSpy).toHaveBeenCalledWith('preprints', mockProviderId);
+  });
+
+  it('should return correct labelKey for a subscription event', () => {
+    expect(component.labelKey(SubscriptionEvent.ProviderNewPendingSubmissions)).toBe(
+      'moderation.notificationPreferences.items.provider_new_pending_submissions'
+    );
+  });
+
+  it('should dispatch UpdateProviderSubscription and show toast on frequency change', () => {
+    fixture.detectChanges();
+    const updateSpy = jest.fn().mockReturnValue(of({}));
+    component.actions = { ...component.actions, updateProviderSubscription: updateSpy };
+
+    component.onFrequencyChange(MOCK_PROVIDER_SUBSCRIPTIONS[0], SubscriptionFrequency.Daily);
+
+    expect(updateSpy).toHaveBeenCalledWith({
+      providerType: 'preprints',
+      providerId: mockProviderId,
+      subscriptionId: 'sub-1',
+      frequency: SubscriptionFrequency.Daily,
+    });
+    expect(toastService.showSuccess).toHaveBeenCalledWith('moderation.notificationPreferences.successUpdate');
+  });
+
+  it('should build frequencyOptions from SubscriptionFrequency enum', () => {
+    expect(component.frequencyOptions).toEqual(
+      Object.entries(SubscriptionFrequency).map(([key, value]) => ({ label: key, value }))
+    );
+  });
+
+  it('should populate form controls when subscriptions load', () => {
+    fixture.detectChanges();
+    expect(component.form.contains('sub-1')).toBe(true);
+    expect(component.form.contains('sub-2')).toBe(true);
+    expect(component.form.get('sub-1')?.value).toBe(SubscriptionFrequency.Instant);
+    expect(component.form.get('sub-2')?.value).toBe(SubscriptionFrequency.Never);
+  });
+
+  it('should have actions defined', () => {
+    expect(component.actions).toBeDefined();
+    expect(component.actions.getProviderSubscriptions).toBeDefined();
+    expect(component.actions.updateProviderSubscription).toBeDefined();
   });
 });

--- a/src/app/features/moderation/components/notification-settings/notification-settings.component.ts
+++ b/src/app/features/moderation/components/notification-settings/notification-settings.component.ts
@@ -8,22 +8,13 @@ import { Skeleton } from 'primeng/skeleton';
 import { of } from 'rxjs';
 import { map } from 'rxjs/operators';
 
-import {
-  ChangeDetectionStrategy,
-  Component,
-  computed,
-  DestroyRef,
-  effect,
-  inject,
-  OnInit,
-  Signal,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, effect, inject, OnInit, Signal } from '@angular/core';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
-import { FormBuilder, FormControl, ReactiveFormsModule } from '@angular/forms';
+import { FormBuilder, FormControl, FormRecord, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 
-import { ResourceType } from '@osf/shared/enums/resource-type.enum';
-import { SubscriptionEvent } from '@osf/shared/enums/subscriptions/subscription-event.enum';
+import { SUBSCRIPTION_FREQUENCY_OPTIONS } from '@osf/shared/constants/subscription-options.const';
+import { CurrentResourceType } from '@osf/shared/enums/resource-type.enum';
 import { SubscriptionFrequency } from '@osf/shared/enums/subscriptions/subscription-frequency.enum';
 import { NotificationSubscription } from '@osf/shared/models/notifications/notification-subscription.model';
 import { ToastService } from '@osf/shared/services/toast.service';
@@ -33,12 +24,6 @@ import {
   ProviderSubscriptionsSelectors,
   UpdateProviderSubscription,
 } from '../../store/provider-subscriptions';
-
-const PROVIDER_TYPE_MAP: Partial<Record<ResourceType, string>> = {
-  [ResourceType.Preprint]: 'preprints',
-  [ResourceType.Collection]: 'collections',
-  [ResourceType.Registration]: 'registrations',
-};
 
 @Component({
   selector: 'osf-notification-settings',
@@ -56,23 +41,16 @@ export class NotificationSettingsComponent implements OnInit {
   readonly providerId = toSignal(
     this.route.parent?.params.pipe(map((params) => params['providerId'])) ?? of(undefined)
   );
-  readonly resourceType: Signal<ResourceType | undefined> = toSignal(
-    this.route.data.pipe(map((params) => params['resourceType'])) ?? of(undefined)
+  readonly resourceType: Signal<CurrentResourceType | undefined> = toSignal(
+    this.route.data.pipe(map((params) => params['resourceType']))
   );
-  readonly providerType = computed(() => {
-    const rt = this.resourceType();
-    return rt !== undefined ? PROVIDER_TYPE_MAP[rt] : undefined;
-  });
 
   subscriptions = select(ProviderSubscriptionsSelectors.getSubscriptions);
   isLoading = select(ProviderSubscriptionsSelectors.isLoading);
 
-  form = this.fb.group({} as Record<string, FormControl<SubscriptionFrequency>>);
+  readonly form = new FormRecord<FormControl<SubscriptionFrequency>>({});
 
-  frequencyOptions = Object.entries(SubscriptionFrequency).map(([key, value]) => ({
-    label: key,
-    value,
-  }));
+  readonly frequencyOptions = SUBSCRIPTION_FREQUENCY_OPTIONS;
 
   private readonly actions = createDispatchMap({
     getProviderSubscriptions: GetProviderSubscriptions,
@@ -82,27 +60,32 @@ export class NotificationSettingsComponent implements OnInit {
   constructor() {
     effect(() => {
       const subs = this.subscriptions();
-      Object.keys(this.form.controls).forEach((k) => this.form.removeControl(k, { emitEvent: false }));
       subs.forEach((sub) => {
-        this.form.addControl(sub.id, this.fb.control(sub.frequency, { nonNullable: true }), { emitEvent: false });
+        const control = this.form.controls[sub.id];
+        if (!control) {
+          this.form.addControl(sub.id, this.fb.control(sub.frequency, { nonNullable: true }), { emitEvent: false });
+          return;
+        }
+
+        if (control.value !== sub.frequency) {
+          control.setValue(sub.frequency, { emitEvent: false });
+        }
       });
     });
   }
 
   ngOnInit(): void {
-    const providerType = this.providerType();
+    const providerType = this.resourceType();
     const providerId = this.providerId();
     if (providerType && providerId) {
       this.actions.getProviderSubscriptions(providerType, providerId);
     }
   }
 
-  labelKey(event: SubscriptionEvent): string {
-    return `moderation.notificationPreferences.items.${event}`;
-  }
-
   onFrequencyChange(sub: NotificationSubscription, frequency: SubscriptionFrequency): void {
-    const providerType = this.providerType();
+    if (sub.frequency === frequency) return;
+
+    const providerType = this.resourceType();
     const providerId = this.providerId();
     if (!providerType || !providerId) return;
 
@@ -114,8 +97,6 @@ export class NotificationSettingsComponent implements OnInit {
         frequency,
       })
       .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe(() => {
-        this.toastService.showSuccess('moderation.notificationPreferences.successUpdate');
-      });
+      .subscribe(() => this.toastService.showSuccess('moderation.notificationPreferences.successUpdate'));
   }
 }

--- a/src/app/features/moderation/components/notification-settings/notification-settings.component.ts
+++ b/src/app/features/moderation/components/notification-settings/notification-settings.component.ts
@@ -1,13 +1,121 @@
+import { createDispatchMap, select } from '@ngxs/store';
+
 import { TranslatePipe } from '@ngx-translate/core';
 
-import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { RouterLink } from '@angular/router';
+import { Select } from 'primeng/select';
+import { Skeleton } from 'primeng/skeleton';
+
+import { of } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  DestroyRef,
+  effect,
+  inject,
+  OnInit,
+  Signal,
+} from '@angular/core';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
+import { FormBuilder, FormControl, ReactiveFormsModule } from '@angular/forms';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+
+import { ResourceType } from '@osf/shared/enums/resource-type.enum';
+import { SubscriptionEvent } from '@osf/shared/enums/subscriptions/subscription-event.enum';
+import { SubscriptionFrequency } from '@osf/shared/enums/subscriptions/subscription-frequency.enum';
+import { NotificationSubscription } from '@osf/shared/models/notifications/notification-subscription.model';
+import { ToastService } from '@osf/shared/services/toast.service';
+
+import {
+  GetProviderSubscriptions,
+  ProviderSubscriptionsSelectors,
+  UpdateProviderSubscription,
+} from '../../store/provider-subscriptions';
+
+const PROVIDER_TYPE_MAP: Partial<Record<ResourceType, string>> = {
+  [ResourceType.Preprint]: 'preprints',
+  [ResourceType.Collection]: 'collections',
+  [ResourceType.Registration]: 'registrations',
+};
 
 @Component({
   selector: 'osf-notification-settings',
-  imports: [TranslatePipe, RouterLink],
+  imports: [TranslatePipe, RouterLink, ReactiveFormsModule, Select, Skeleton],
   templateUrl: './notification-settings.component.html',
   styleUrl: './notification-settings.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class NotificationSettingsComponent {}
+export class NotificationSettingsComponent implements OnInit {
+  private readonly route = inject(ActivatedRoute);
+  private readonly fb = inject(FormBuilder);
+  private readonly toastService = inject(ToastService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  readonly providerId = toSignal(
+    this.route.parent?.params.pipe(map((params) => params['providerId'])) ?? of(undefined)
+  );
+  readonly resourceType: Signal<ResourceType | undefined> = toSignal(
+    this.route.data.pipe(map((params) => params['resourceType'])) ?? of(undefined)
+  );
+  readonly providerType = computed(() => {
+    const rt = this.resourceType();
+    return rt !== undefined ? PROVIDER_TYPE_MAP[rt] : undefined;
+  });
+
+  subscriptions = select(ProviderSubscriptionsSelectors.getSubscriptions);
+  isLoading = select(ProviderSubscriptionsSelectors.isLoading);
+
+  form = this.fb.group({} as Record<string, FormControl<SubscriptionFrequency>>);
+
+  frequencyOptions = Object.entries(SubscriptionFrequency).map(([key, value]) => ({
+    label: key,
+    value,
+  }));
+
+  private readonly actions = createDispatchMap({
+    getProviderSubscriptions: GetProviderSubscriptions,
+    updateProviderSubscription: UpdateProviderSubscription,
+  });
+
+  constructor() {
+    effect(() => {
+      const subs = this.subscriptions();
+      Object.keys(this.form.controls).forEach((k) => this.form.removeControl(k, { emitEvent: false }));
+      subs.forEach((sub) => {
+        this.form.addControl(sub.id, this.fb.control(sub.frequency, { nonNullable: true }), { emitEvent: false });
+      });
+    });
+  }
+
+  ngOnInit(): void {
+    const providerType = this.providerType();
+    const providerId = this.providerId();
+    if (providerType && providerId) {
+      this.actions.getProviderSubscriptions(providerType, providerId);
+    }
+  }
+
+  labelKey(event: SubscriptionEvent): string {
+    return `moderation.notificationPreferences.items.${event}`;
+  }
+
+  onFrequencyChange(sub: NotificationSubscription, frequency: SubscriptionFrequency): void {
+    const providerType = this.providerType();
+    const providerId = this.providerId();
+    if (!providerType || !providerId) return;
+
+    this.actions
+      .updateProviderSubscription({
+        providerType,
+        providerId,
+        subscriptionId: sub.id,
+        frequency,
+      })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => {
+        this.toastService.showSuccess('moderation.notificationPreferences.successUpdate');
+      });
+  }
+}

--- a/src/app/features/moderation/preprint-moderation.routes.ts
+++ b/src/app/features/moderation/preprint-moderation.routes.ts
@@ -2,7 +2,7 @@ import { provideStates } from '@ngxs/store';
 
 import { Routes } from '@angular/router';
 
-import { ResourceType } from '@osf/shared/enums/resource-type.enum';
+import { CurrentResourceType, ResourceType } from '@osf/shared/enums/resource-type.enum';
 
 import { ModeratorsState } from './store/moderators';
 import { PreprintModerationState } from './store/preprint-moderation';
@@ -52,7 +52,7 @@ export const preprintModerationRoutes: Routes = [
           import('./components/notification-settings/notification-settings.component').then(
             (m) => m.NotificationSettingsComponent
           ),
-        data: { tab: PreprintModerationTab.Notifications, resourceType: ResourceType.Preprint },
+        data: { tab: PreprintModerationTab.Notifications, resourceType: CurrentResourceType.Preprints },
         providers: [provideStates([ProviderSubscriptionsState])],
       },
       {

--- a/src/app/features/moderation/preprint-moderation.routes.ts
+++ b/src/app/features/moderation/preprint-moderation.routes.ts
@@ -6,6 +6,7 @@ import { ResourceType } from '@osf/shared/enums/resource-type.enum';
 
 import { ModeratorsState } from './store/moderators';
 import { PreprintModerationState } from './store/preprint-moderation';
+import { ProviderSubscriptionsState } from './store/provider-subscriptions';
 import { PreprintModerationTab } from './enums';
 
 export const preprintModerationRoutes: Routes = [
@@ -51,7 +52,8 @@ export const preprintModerationRoutes: Routes = [
           import('./components/notification-settings/notification-settings.component').then(
             (m) => m.NotificationSettingsComponent
           ),
-        data: { tab: PreprintModerationTab.Notifications },
+        data: { tab: PreprintModerationTab.Notifications, resourceType: ResourceType.Preprint },
+        providers: [provideStates([ProviderSubscriptionsState])],
       },
       {
         path: 'settings',

--- a/src/app/features/moderation/registry-moderation.routes.ts
+++ b/src/app/features/moderation/registry-moderation.routes.ts
@@ -2,7 +2,7 @@ import { provideStates } from '@ngxs/store';
 
 import { Routes } from '@angular/router';
 
-import { ResourceType } from '@osf/shared/enums/resource-type.enum';
+import { CurrentResourceType, ResourceType } from '@osf/shared/enums/resource-type.enum';
 
 import { ModeratorsState } from './store/moderators';
 import { ProviderSubscriptionsState } from './store/provider-subscriptions';
@@ -52,7 +52,7 @@ export const registryModerationRoutes: Routes = [
           import('./components/notification-settings/notification-settings.component').then(
             (m) => m.NotificationSettingsComponent
           ),
-        data: { tab: RegistryModerationTab.Settings, resourceType: ResourceType.Registration },
+        data: { tab: RegistryModerationTab.Settings, resourceType: CurrentResourceType.Registrations },
         providers: [provideStates([ProviderSubscriptionsState])],
       },
     ],

--- a/src/app/features/moderation/registry-moderation.routes.ts
+++ b/src/app/features/moderation/registry-moderation.routes.ts
@@ -5,6 +5,7 @@ import { Routes } from '@angular/router';
 import { ResourceType } from '@osf/shared/enums/resource-type.enum';
 
 import { ModeratorsState } from './store/moderators';
+import { ProviderSubscriptionsState } from './store/provider-subscriptions';
 import { RegistryModerationState } from './store/registry-moderation';
 import { RegistryModerationTab } from './enums';
 
@@ -48,8 +49,11 @@ export const registryModerationRoutes: Routes = [
       {
         path: 'settings',
         loadComponent: () =>
-          import('./components/registry-settings/registry-settings.component').then((m) => m.RegistrySettingsComponent),
-        data: { tab: RegistryModerationTab.Settings },
+          import('./components/notification-settings/notification-settings.component').then(
+            (m) => m.NotificationSettingsComponent
+          ),
+        data: { tab: RegistryModerationTab.Settings, resourceType: ResourceType.Registration },
+        providers: [provideStates([ProviderSubscriptionsState])],
       },
     ],
   },

--- a/src/app/features/moderation/services/index.ts
+++ b/src/app/features/moderation/services/index.ts
@@ -1,3 +1,4 @@
 export { ModeratorsService } from './moderators.service';
 export { PreprintModerationService } from './preprint-moderation.service';
+export { ProviderSubscriptionService } from './provider-subscription.service';
 export { RegistryModerationService } from './registry-moderation.service';

--- a/src/app/features/moderation/services/provider-subscription.service.ts
+++ b/src/app/features/moderation/services/provider-subscription.service.ts
@@ -1,0 +1,56 @@
+import { map, Observable } from 'rxjs';
+
+import { inject, Injectable } from '@angular/core';
+
+import { ENVIRONMENT } from '@core/provider/environment.provider';
+import { SubscriptionFrequency } from '@osf/shared/enums/subscriptions/subscription-frequency.enum';
+import { SubscriptionType } from '@osf/shared/enums/subscriptions/subscription-type.enum';
+import { NotificationSubscriptionMapper } from '@osf/shared/mappers/notification-subscription.mapper';
+import { JsonApiResponse } from '@osf/shared/models/common/json-api.model';
+import { NotificationSubscription } from '@osf/shared/models/notifications/notification-subscription.model';
+import { NotificationSubscriptionGetResponseJsonApi } from '@osf/shared/models/notifications/notification-subscription-json-api.model';
+import { JsonApiService } from '@osf/shared/services/json-api.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ProviderSubscriptionService {
+  private readonly jsonApiService = inject(JsonApiService);
+  private readonly environment = inject(ENVIRONMENT);
+
+  private providerUrl(providerType: string, providerId: string): string {
+    return `${this.environment.apiDomainUrl}/v2/providers/${providerType}/${providerId}/subscriptions/`;
+  }
+
+  getProviderSubscriptions(providerType: string, providerId: string): Observable<NotificationSubscription[]> {
+    return this.jsonApiService
+      .get<
+        JsonApiResponse<NotificationSubscriptionGetResponseJsonApi[], null>
+      >(this.providerUrl(providerType, providerId))
+      .pipe(
+        map((responses) => responses.data.map((response) => NotificationSubscriptionMapper.fromGetResponse(response)))
+      );
+  }
+
+  updateProviderSubscription(
+    providerType: string,
+    providerId: string,
+    subscriptionId: string,
+    frequency: SubscriptionFrequency
+  ): Observable<NotificationSubscription> {
+    const request = {
+      data: {
+        id: subscriptionId,
+        type: SubscriptionType.Node,
+        attributes: { frequency },
+      },
+    };
+
+    return this.jsonApiService
+      .patch<NotificationSubscriptionGetResponseJsonApi>(
+        `${this.providerUrl(providerType, providerId)}${subscriptionId}/`,
+        request
+      )
+      .pipe(map((response) => NotificationSubscriptionMapper.fromGetResponse(response)));
+  }
+}

--- a/src/app/features/moderation/store/provider-subscriptions/index.ts
+++ b/src/app/features/moderation/store/provider-subscriptions/index.ts
@@ -1,0 +1,4 @@
+export * from './provider-subscriptions.actions';
+export * from './provider-subscriptions.model';
+export * from './provider-subscriptions.selectors';
+export * from './provider-subscriptions.state';

--- a/src/app/features/moderation/store/provider-subscriptions/provider-subscriptions.actions.ts
+++ b/src/app/features/moderation/store/provider-subscriptions/provider-subscriptions.actions.ts
@@ -1,0 +1,23 @@
+import { SubscriptionFrequency } from '@osf/shared/enums/subscriptions/subscription-frequency.enum';
+
+export class GetProviderSubscriptions {
+  static readonly type = '[Provider Subscriptions] Get';
+
+  constructor(
+    public providerType: string,
+    public providerId: string
+  ) {}
+}
+
+export class UpdateProviderSubscription {
+  static readonly type = '[Provider Subscriptions] Update';
+
+  constructor(
+    public payload: {
+      providerType: string;
+      providerId: string;
+      subscriptionId: string;
+      frequency: SubscriptionFrequency;
+    }
+  ) {}
+}

--- a/src/app/features/moderation/store/provider-subscriptions/provider-subscriptions.model.ts
+++ b/src/app/features/moderation/store/provider-subscriptions/provider-subscriptions.model.ts
@@ -1,0 +1,14 @@
+import { NotificationSubscription } from '@osf/shared/models/notifications/notification-subscription.model';
+import { AsyncStateModel } from '@osf/shared/models/store/async-state.model';
+
+export interface ProviderSubscriptionsStateModel {
+  subscriptions: AsyncStateModel<NotificationSubscription[]>;
+}
+
+export const PROVIDER_SUBSCRIPTIONS_STATE_DEFAULTS: ProviderSubscriptionsStateModel = {
+  subscriptions: {
+    data: [],
+    isLoading: false,
+    error: '',
+  },
+};

--- a/src/app/features/moderation/store/provider-subscriptions/provider-subscriptions.selectors.ts
+++ b/src/app/features/moderation/store/provider-subscriptions/provider-subscriptions.selectors.ts
@@ -1,0 +1,18 @@
+import { Selector } from '@ngxs/store';
+
+import { NotificationSubscription } from '@osf/shared/models/notifications/notification-subscription.model';
+
+import { ProviderSubscriptionsStateModel } from './provider-subscriptions.model';
+import { ProviderSubscriptionsState } from './provider-subscriptions.state';
+
+export class ProviderSubscriptionsSelectors {
+  @Selector([ProviderSubscriptionsState])
+  static getSubscriptions(state: ProviderSubscriptionsStateModel): NotificationSubscription[] {
+    return state.subscriptions.data;
+  }
+
+  @Selector([ProviderSubscriptionsState])
+  static isLoading(state: ProviderSubscriptionsStateModel): boolean {
+    return state.subscriptions.isLoading;
+  }
+}

--- a/src/app/features/moderation/store/provider-subscriptions/provider-subscriptions.state.ts
+++ b/src/app/features/moderation/store/provider-subscriptions/provider-subscriptions.state.ts
@@ -1,0 +1,70 @@
+import { Action, State, StateContext } from '@ngxs/store';
+import { patch, updateItem } from '@ngxs/store/operators';
+
+import { catchError, tap } from 'rxjs';
+
+import { inject, Injectable } from '@angular/core';
+
+import { handleSectionError } from '@osf/shared/helpers/state-error.handler';
+import { NotificationSubscription } from '@osf/shared/models/notifications/notification-subscription.model';
+
+import { ProviderSubscriptionService } from '../../services';
+
+import { GetProviderSubscriptions, UpdateProviderSubscription } from './provider-subscriptions.actions';
+import { PROVIDER_SUBSCRIPTIONS_STATE_DEFAULTS, ProviderSubscriptionsStateModel } from './provider-subscriptions.model';
+
+@State<ProviderSubscriptionsStateModel>({
+  name: 'providerSubscriptions',
+  defaults: PROVIDER_SUBSCRIPTIONS_STATE_DEFAULTS,
+})
+@Injectable()
+export class ProviderSubscriptionsState {
+  private readonly providerSubscriptionService = inject(ProviderSubscriptionService);
+
+  @Action(GetProviderSubscriptions)
+  getProviderSubscriptions(ctx: StateContext<ProviderSubscriptionsStateModel>, action: GetProviderSubscriptions) {
+    ctx.setState(patch({ subscriptions: patch({ isLoading: true }) }));
+
+    return this.providerSubscriptionService.getProviderSubscriptions(action.providerType, action.providerId).pipe(
+      tap((subscriptions) => {
+        ctx.setState(
+          patch({
+            subscriptions: patch({
+              data: subscriptions,
+              isLoading: false,
+            }),
+          })
+        );
+      }),
+      catchError((error) => handleSectionError(ctx, 'subscriptions', error))
+    );
+  }
+
+  @Action(UpdateProviderSubscription)
+  updateProviderSubscription(ctx: StateContext<ProviderSubscriptionsStateModel>, action: UpdateProviderSubscription) {
+    return this.providerSubscriptionService
+      .updateProviderSubscription(
+        action.payload.providerType,
+        action.payload.providerId,
+        action.payload.subscriptionId,
+        action.payload.frequency
+      )
+      .pipe(
+        tap((updatedSubscription) => {
+          ctx.setState(
+            patch({
+              subscriptions: patch({
+                data: updateItem<NotificationSubscription>(
+                  (sub) => sub.id === action.payload.subscriptionId,
+                  updatedSubscription
+                ),
+                error: null,
+                isLoading: false,
+              }),
+            })
+          );
+        }),
+        catchError((error) => handleSectionError(ctx, 'subscriptions', error))
+      );
+  }
+}

--- a/src/app/shared/constants/subscription-options.const.ts
+++ b/src/app/shared/constants/subscription-options.const.ts
@@ -1,0 +1,7 @@
+import { SubscriptionFrequency } from '../enums/subscriptions/subscription-frequency.enum';
+
+export const SUBSCRIPTION_FREQUENCY_OPTIONS = [
+  { label: 'settings.notifications.frequency.never', value: SubscriptionFrequency.Never },
+  { label: 'settings.notifications.frequency.daily', value: SubscriptionFrequency.Daily },
+  { label: 'settings.notifications.frequency.instant', value: SubscriptionFrequency.Instant },
+];

--- a/src/app/shared/enums/subscriptions/subscription-event.enum.ts
+++ b/src/app/shared/enums/subscriptions/subscription-event.enum.ts
@@ -2,4 +2,6 @@ export enum SubscriptionEvent {
   GlobalFileUpdated = 'global_file_updated',
   GlobalReviews = 'global_reviews',
   FileUpdated = 'file_updated',
+  ProviderNewPendingSubmissions = 'provider_new_pending_submissions',
+  ProviderNewPendingWithdrawRequests = 'provider_new_pending_withdraw_requests',
 }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1711,6 +1711,11 @@
           "preprints": "Preprint submissions updated"
         },
         "successUpdate": "Notification preferences successfully updated."
+      },
+      "frequency": {
+        "daily": "Daily",
+        "instant": "Instant",
+        "never": "Never"
       }
     },
     "addons": {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1567,6 +1567,15 @@
       "titleZA": "Title: Z-A",
       "oldest": "Date: oldest to newest",
       "newest": "Date: newest to oldest"
+    },
+    "notificationPreferences": {
+      "title": "Configure reviews notification preferences",
+      "note": "To configure other notification preferences visit your",
+      "items": {
+        "provider_new_pending_submissions": "New pending submissions",
+        "provider_new_pending_withdraw_requests": "New pending withdraw requests"
+      },
+      "successUpdate": "Notification preference updated successfully"
     }
   },
   "settings": {


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the correct branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `feat(ENG-123): some really great stuff`
-->

- Ticket: [ENG-9810]
- Feature flag: fix

## Purpose

<!-- Describe the purpose of your changes. -->

## Summary of Changes

Moderators of Collections, Registries, and Preprints need to control
how they receive notifications about moderation activity (new pending
submissions, withdrawal requests) — instant, daily, or none.
Previously, the Settings/Notifications tabs in the moderation pages
were empty placeholders that just pointed users away to their global
user settings. That was insufficient because these are provider-level
subscriptions (scoped to a specific provider), not global ones.

The changes wire up the real OSF API
(/v2/providers/{type}/{id}/subscriptions/) so each moderation portal's
 notification tab now:
1. Loads the actual per-provider subscription preferences for the
logged-in moderator
2. Lets them change the frequency via dropdowns, saved immediately via
 PATCH

## Screenshot(s)

<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
