### PR TITLE
[ENG-10707] update project count metrics if user is not contributor or is not authentified

### DIFF
--- a/src/app/features/project/project.component.spec.ts
+++ b/src/app/features/project/project.component.spec.ts
@@ -2,7 +2,7 @@ import { Store } from '@ngxs/store';
 
 import { MockProvider } from 'ng-mocks';
 
-import { TestBed } from '@angular/core/testing';
+import { fakeAsync, TestBed } from '@angular/core/testing';
 import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
 
 import { HelpScoutService } from '@core/services/help-scout.service';
@@ -95,6 +95,7 @@ function setup(overrides: SetupOverrides = {}) {
     { selector: ContributorsSelectors.getBibliographicContributors, value: [] },
     { selector: ContributorsSelectors.isBibliographicContributorsLoading, value: false },
     { selector: CurrentResourceSelectors.getCurrentResource, value: null },
+    { selector: CurrentResourceSelectors.hasNoPermissions, value: false },
   ];
 
   const signals = mergeSignalOverrides(defaultSignals, overrides.selectorOverrides);
@@ -227,16 +228,20 @@ describe('Component: Project', () => {
     expect(metaTagsService.updateMetaTags).not.toHaveBeenCalled();
   });
 
-  it('should send analytics on NavigationEnd', () => {
-    const { routerBuilder, analyticsService } = setup();
-
+  it('should send analytics on NavigationEnd', fakeAsync(() => {
+    const mockResource = { id: 'project-1' };
+    const { routerBuilder, analyticsService } = setup({
+      selectorOverrides: [
+        { selector: CurrentResourceSelectors.getCurrentResource, value: mockResource },
+        { selector: CurrentResourceSelectors.hasNoPermissions, value: true },
+      ],
+    });
     routerBuilder.emit(new NavigationEnd(1, '/project-1', '/project-1/overview'));
-
     expect(analyticsService.sendCountedUsageForRegistrationAndProjects).toHaveBeenCalledWith(
       '/project-1/overview',
-      null
+      mockResource
     );
-  });
+  }));
 
   it('should call unsetResourceType on destroy', () => {
     const { component, helpScoutService } = setup();

--- a/src/app/features/project/project.component.ts
+++ b/src/app/features/project/project.component.ts
@@ -31,6 +31,7 @@ import { AnalyticsService } from '@shared/services/analytics.service';
 import { CurrentResourceSelectors } from '@shared/stores/current-resource';
 
 import { GetProjectById, GetProjectIdentifiers, GetProjectLicense, ProjectOverviewSelectors } from './overview/store';
+import { UserSelectors } from '@core/store/user';
 
 @Component({
   selector: 'osf-project',
@@ -52,6 +53,7 @@ export class ProjectComponent implements OnDestroy {
   private readonly router = inject(Router);
   private readonly analyticsService = inject(AnalyticsService);
 
+  readonly currentUser = select(UserSelectors.getCurrentUser);
   readonly currentResource = select(CurrentResourceSelectors.getCurrentResource);
   readonly currentProject = select(ProjectOverviewSelectors.getProject);
   readonly isProjectLoading = select(ProjectOverviewSelectors.getProjectLoading);
@@ -143,10 +145,15 @@ export class ProjectComponent implements OnDestroy {
       .subscribe((event: NavigationEnd) => {
         this.canonicalPath.set(this.getCanonicalPathFromSnapshot());
         this.isFileDetailRoute.set(this.isFileDetailRouteFromSnapshot());
-        this.analyticsService.sendCountedUsageForRegistrationAndProjects(
-          event.urlAfterRedirects,
-          this.currentResource()
-        );
+        const contributors = this.bibliographicContributors()
+        const user = this.currentUser()
+        // update project count metrics if user is not contributor or is not authentified
+        if (!user?.id || !contributors.some((contributor) => contributor.userId === user.id)) {
+          this.analyticsService.sendCountedUsageForRegistrationAndProjects(
+            event.urlAfterRedirects,
+            this.currentResource()
+          );
+        }
       });
   }
 

--- a/src/app/features/project/project.component.ts
+++ b/src/app/features/project/project.component.ts
@@ -145,10 +145,7 @@ export class ProjectComponent implements OnDestroy {
       .subscribe((event: NavigationEnd) => {
         this.canonicalPath.set(this.getCanonicalPathFromSnapshot());
         this.isFileDetailRoute.set(this.isFileDetailRouteFromSnapshot());
-        const contributors = this.bibliographicContributors();
-        const user = this.currentUser();
-        // update project count metrics if user is not contributor or is not authentified
-        if (!user?.id || !contributors.some((contributor) => contributor.userId === user.id)) {
+if (this.hasNoPermissions()) {
           this.analyticsService.sendCountedUsageForRegistrationAndProjects(
             event.urlAfterRedirects,
             this.currentResource()

--- a/src/app/features/project/project.component.ts
+++ b/src/app/features/project/project.component.ts
@@ -145,7 +145,7 @@ export class ProjectComponent implements OnDestroy {
       .subscribe((event: NavigationEnd) => {
         this.canonicalPath.set(this.getCanonicalPathFromSnapshot());
         this.isFileDetailRoute.set(this.isFileDetailRouteFromSnapshot());
-        if (this.hasNoPermissions()) {
+        if (this.currentResource()?.id && this.hasNoPermissions()) {
           this.analyticsService.sendCountedUsageForRegistrationAndProjects(
             event.urlAfterRedirects,
             this.currentResource()

--- a/src/app/features/project/project.component.ts
+++ b/src/app/features/project/project.component.ts
@@ -53,7 +53,7 @@ export class ProjectComponent implements OnDestroy {
   private readonly router = inject(Router);
   private readonly analyticsService = inject(AnalyticsService);
 
-  readonly hasNoPermissions = select(ProjectOverviewSelectors.hasNoPermissions);
+  readonly hasNoPermissions = select(CurrentResourceSelectors.hasNoPermissions);
   readonly currentResource = select(CurrentResourceSelectors.getCurrentResource);
   readonly currentProject = select(ProjectOverviewSelectors.getProject);
   readonly isProjectLoading = select(ProjectOverviewSelectors.getProjectLoading);

--- a/src/app/features/project/project.component.ts
+++ b/src/app/features/project/project.component.ts
@@ -53,7 +53,7 @@ export class ProjectComponent implements OnDestroy {
   private readonly router = inject(Router);
   private readonly analyticsService = inject(AnalyticsService);
 
-  readonly currentUser = select(UserSelectors.getCurrentUser);
+ readonly hasNoPermissions = select(ProjectOverviewSelectors.hasNoPermissions);
   readonly currentResource = select(CurrentResourceSelectors.getCurrentResource);
   readonly currentProject = select(ProjectOverviewSelectors.getProject);
   readonly isProjectLoading = select(ProjectOverviewSelectors.getProjectLoading);

--- a/src/app/features/project/project.component.ts
+++ b/src/app/features/project/project.component.ts
@@ -18,6 +18,7 @@ import { ActivatedRoute, NavigationEnd, Router, RouterOutlet } from '@angular/ro
 
 import { HelpScoutService } from '@core/services/help-scout.service';
 import { PrerenderReadyService } from '@core/services/prerender-ready.service';
+import { UserSelectors } from '@core/store/user';
 import { ResourceType } from '@osf/shared/enums/resource-type.enum';
 import {
   getDeepestCanonicalPathTemplateFromSnapshot,
@@ -31,7 +32,6 @@ import { AnalyticsService } from '@shared/services/analytics.service';
 import { CurrentResourceSelectors } from '@shared/stores/current-resource';
 
 import { GetProjectById, GetProjectIdentifiers, GetProjectLicense, ProjectOverviewSelectors } from './overview/store';
-import { UserSelectors } from '@core/store/user';
 
 @Component({
   selector: 'osf-project',
@@ -145,8 +145,8 @@ export class ProjectComponent implements OnDestroy {
       .subscribe((event: NavigationEnd) => {
         this.canonicalPath.set(this.getCanonicalPathFromSnapshot());
         this.isFileDetailRoute.set(this.isFileDetailRouteFromSnapshot());
-        const contributors = this.bibliographicContributors()
-        const user = this.currentUser()
+        const contributors = this.bibliographicContributors();
+        const user = this.currentUser();
         // update project count metrics if user is not contributor or is not authentified
         if (!user?.id || !contributors.some((contributor) => contributor.userId === user.id)) {
           this.analyticsService.sendCountedUsageForRegistrationAndProjects(

--- a/src/app/features/project/project.component.ts
+++ b/src/app/features/project/project.component.ts
@@ -18,7 +18,6 @@ import { ActivatedRoute, NavigationEnd, Router, RouterOutlet } from '@angular/ro
 
 import { HelpScoutService } from '@core/services/help-scout.service';
 import { PrerenderReadyService } from '@core/services/prerender-ready.service';
-import { UserSelectors } from '@core/store/user';
 import { ResourceType } from '@osf/shared/enums/resource-type.enum';
 import {
   getDeepestCanonicalPathTemplateFromSnapshot,

--- a/src/app/features/project/project.component.ts
+++ b/src/app/features/project/project.component.ts
@@ -53,7 +53,7 @@ export class ProjectComponent implements OnDestroy {
   private readonly router = inject(Router);
   private readonly analyticsService = inject(AnalyticsService);
 
- readonly hasNoPermissions = select(ProjectOverviewSelectors.hasNoPermissions);
+  readonly hasNoPermissions = select(ProjectOverviewSelectors.hasNoPermissions);
   readonly currentResource = select(CurrentResourceSelectors.getCurrentResource);
   readonly currentProject = select(ProjectOverviewSelectors.getProject);
   readonly isProjectLoading = select(ProjectOverviewSelectors.getProjectLoading);
@@ -145,7 +145,7 @@ export class ProjectComponent implements OnDestroy {
       .subscribe((event: NavigationEnd) => {
         this.canonicalPath.set(this.getCanonicalPathFromSnapshot());
         this.isFileDetailRoute.set(this.isFileDetailRouteFromSnapshot());
-if (this.hasNoPermissions()) {
+        if (this.hasNoPermissions()) {
           this.analyticsService.sendCountedUsageForRegistrationAndProjects(
             event.urlAfterRedirects,
             this.currentResource()

--- a/src/app/features/registry/registry.component.spec.ts
+++ b/src/app/features/registry/registry.component.spec.ts
@@ -3,7 +3,7 @@ import { Store } from '@ngxs/store';
 import { MockProvider } from 'ng-mocks';
 
 import { PLATFORM_ID, Provider } from '@angular/core';
-import { TestBed } from '@angular/core/testing';
+import { fakeAsync, TestBed } from '@angular/core/testing';
 import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
 
 import { HelpScoutService } from '@core/services/help-scout.service';
@@ -32,7 +32,7 @@ import { MetaTagsBuilderServiceMockFactory } from '@testing/providers/meta-tags-
 import { PrerenderReadyServiceMockFactory } from '@testing/providers/prerender-ready.service.mock';
 import { ActivatedRouteMockBuilder } from '@testing/providers/route-provider.mock';
 import { RouterMockBuilder } from '@testing/providers/router-provider.mock';
-import { provideMockStore } from '@testing/providers/store-provider.mock';
+import { mergeSignalOverrides, provideMockStore, SignalOverride } from '@testing/providers/store-provider.mock';
 
 interface SetupOverrides {
   registryId?: string;
@@ -40,6 +40,7 @@ interface SetupOverrides {
   identifiers?: IdentifierModel[];
   canonicalPath?: string;
   platform?: string;
+  selectorOverrides?: SignalOverride[];
 }
 
 function setup(overrides: SetupOverrides = {}) {
@@ -72,6 +73,20 @@ function setup(overrides: SetupOverrides = {}) {
       }) as MetaTagsData
   );
 
+  const defaultSignals: SignalOverride[] = [
+    { selector: RegistrySelectors.getRegistry, value: registry },
+    { selector: RegistrySelectors.isRegistryLoading, value: false },
+    { selector: RegistrySelectors.getIdentifiers, value: identifiers },
+    { selector: RegistrySelectors.getLicense, value: { name: 'MIT' } },
+    { selector: RegistrySelectors.isLicenseLoading, value: false },
+    { selector: ContributorsSelectors.getBibliographicContributors, value: [] },
+    { selector: ContributorsSelectors.isBibliographicContributorsLoading, value: false },
+    { selector: CurrentResourceSelectors.getCurrentResource, value: null },
+    { selector: CurrentResourceSelectors.hasNoPermissions, value: false },
+  ];
+
+  const signals = mergeSignalOverrides(defaultSignals, overrides.selectorOverrides);
+
   const providers: Provider[] = [
     provideOSFCore(),
     MockProvider(HelpScoutService, helpScoutService),
@@ -82,18 +97,7 @@ function setup(overrides: SetupOverrides = {}) {
     MockProvider(AnalyticsService, analyticsService),
     MockProvider(ActivatedRoute, routeBuilder.build()),
     MockProvider(Router, mockRouter),
-    provideMockStore({
-      signals: [
-        { selector: RegistrySelectors.getRegistry, value: registry },
-        { selector: RegistrySelectors.isRegistryLoading, value: false },
-        { selector: RegistrySelectors.getIdentifiers, value: identifiers },
-        { selector: RegistrySelectors.getLicense, value: { name: 'MIT' } },
-        { selector: RegistrySelectors.isLicenseLoading, value: false },
-        { selector: ContributorsSelectors.getBibliographicContributors, value: [] },
-        { selector: ContributorsSelectors.isBibliographicContributorsLoading, value: false },
-        { selector: CurrentResourceSelectors.getCurrentResource, value: null },
-      ],
-    }),
+    provideMockStore({ signals }),
   ];
 
   if (overrides.platform) {
@@ -225,16 +229,20 @@ describe('RegistryComponent', () => {
     expect(metaTagsService.updateMetaTags).not.toHaveBeenCalled();
   });
 
-  it('should send analytics on NavigationEnd event', () => {
-    const { routerBuilder, analyticsService } = setup();
-
+  it('should send analytics on NavigationEnd event', fakeAsync(() => {
+    const mockResource = { id: 'registry-1' };
+    const { routerBuilder, analyticsService } = setup({
+      selectorOverrides: [
+        { selector: CurrentResourceSelectors.getCurrentResource, value: mockResource },
+        { selector: CurrentResourceSelectors.hasNoPermissions, value: true },
+      ],
+    });
     routerBuilder.emit(new NavigationEnd(1, '/registries/registry-1', '/registries/registry-1'));
-
     expect(analyticsService.sendCountedUsageForRegistrationAndProjects).toHaveBeenCalledWith(
       '/registries/registry-1',
-      null
+      mockResource
     );
-  });
+  }));
 
   it('should unset helpScout and clear provider on destroy', () => {
     const { component, store, helpScoutService } = setup();

--- a/src/app/features/registry/registry.component.ts
+++ b/src/app/features/registry/registry.component.ts
@@ -65,6 +65,7 @@ export class RegistryComponent implements OnDestroy {
   });
 
   private readonly registryId = toSignal(this.route.params.pipe(map((params) => params['id'])));
+  readonly hasNoPermissions = select(CurrentResourceSelectors.hasNoPermissions);
   private readonly currentResource = select(CurrentResourceSelectors.getCurrentResource);
   private readonly registry = select(RegistrySelectors.getRegistry);
   private readonly isRegistryLoading = select(RegistrySelectors.isRegistryLoading);
@@ -141,10 +142,12 @@ export class RegistryComponent implements OnDestroy {
       .subscribe((event) => {
         this.canonicalPath.set(this.getCanonicalPathFromSnapshot());
         this.isFileDetailRoute.set(this.isFileDetailRouteFromSnapshot());
-        this.analyticsService.sendCountedUsageForRegistrationAndProjects(
-          event.urlAfterRedirects,
-          this.currentResource()
-        );
+        if (this.currentResource()?.id && this.hasNoPermissions()) {
+          this.analyticsService.sendCountedUsageForRegistrationAndProjects(
+            event.urlAfterRedirects,
+            this.currentResource()
+          );
+        }
       });
   }
 


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the correct branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `feat(ENG-123): some really great stuff`
-->

- Ticket: https://openscience.atlassian.net/browse/ENG-10707
- Feature flag: n/a

## Purpose

When contributors (Admin, Write, or Read) view their own projects, the unique view count increases — which it should not. This inflates analytics data for project owners.

## Summary of Changes

add check to update project count metrics (count_usage call) if user is not contributor or is not authentified


https://github.com/user-attachments/assets/a15984b9-7783-4865-bda3-39648117efc5



## Screenshot(s)

<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
