### PR TITLE
[ENG-10702] Update connectOrcid to properly logging user out

### DIFF
--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -73,13 +73,13 @@ export class AuthService {
     window.location.href = loginUrl;
   }
 
-  logout(): void {
+  logout(nextUrl?: string): void {
     this.loaderService.show();
     this.actions.clearCurrentUser();
 
     if (isPlatformBrowser(this.platformId)) {
       this.cookieService.deleteAll();
-      window.location.href = `${this.webUrl}/logout/?next=${encodeURIComponent('/')}`;
+      window.location.href = `${this.webUrl}/logout/?next=${encodeURIComponent(nextUrl || '/')}`;
     }
   }
 

--- a/src/app/features/settings/profile-settings/components/authenticated-identity/authenticated-identity.component.ts
+++ b/src/app/features/settings/profile-settings/components/authenticated-identity/authenticated-identity.component.ts
@@ -11,6 +11,7 @@ import { NgOptimizedImage } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, inject, OnInit } from '@angular/core';
 
 import { ENVIRONMENT } from '@core/provider/environment.provider';
+import { AuthService } from '@core/services/auth.service';
 import { ExternalIdentityStatus } from '@osf/shared/enums/external-identity-status.enum';
 import { CustomConfirmationService } from '@osf/shared/services/custom-confirmation.service';
 import { LoaderService } from '@osf/shared/services/loader.service';
@@ -31,6 +32,7 @@ import { ProfileSettingsTabOption } from '../../enums';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AuthenticatedIdentityComponent implements OnInit {
+  private readonly authService = inject(AuthService);
   private readonly environment = inject(ENVIRONMENT);
   private readonly customConfirmationService = inject(CustomConfirmationService);
   private readonly toastService = inject(ToastService);
@@ -85,8 +87,6 @@ export class AuthenticatedIdentityComponent implements OnInit {
       service: `${webUrl}/login`,
       next: encodeURIComponent(finalDestination.toString()),
     }).toString();
-    const logoutUrl = new URL(`${webUrl}/logout/`);
-    logoutUrl.searchParams.set('next', casLoginUrl.toString());
-    window.location.href = logoutUrl.toString();
+    this.authService.logout(casLoginUrl.toString());
   }
 }


### PR DESCRIPTION
- Ticket: [ENG-10702]
- Feature flag: n/a

## Purpose
- Prevent bug that makes it look like two users can connect to the same ORCID account

## Summary of Changes
- Properly sign users out of account before redirecting to ORCID login flow
  - Add new optional parameter to `AuthService.logout` to specify `next` query-param

## Screenshot(s)
- NA

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
