### PR TITLE
[ENG-10371] Delete draft preprint functionality was not included in Angular update

### DIFF
--- a/src/app/features/preprints/components/stepper/author-assertion-step/author-assertions-step.component.html
+++ b/src/app/features/preprints/components/stepper/author-assertion-step/author-assertions-step.component.html
@@ -226,13 +226,15 @@
     severity="info"
     (onClick)="backButtonClicked()"
   />
-  <p-button
-    class="w-6 md:w-6rem"
-    styleClass="w-full"
-    [label]="'common.buttons.delete' | translate"
-    severity="danger"
-    (onClick)="deletePreprint()"
-  />
+  @if (showDeleteButton()) {
+    <p-button
+      class="w-6 md:w-6rem"
+      styleClass="w-full"
+      [label]="'common.buttons.delete' | translate"
+      severity="danger"
+      (onClick)="deletePreprint()"
+    />
+  }
   <p-button
     class="w-6 md:w-9rem"
     styleClass="w-full"

--- a/src/app/features/preprints/components/stepper/author-assertion-step/author-assertions-step.component.spec.ts
+++ b/src/app/features/preprints/components/stepper/author-assertion-step/author-assertions-step.component.spec.ts
@@ -121,6 +121,21 @@ describe('AuthorAssertionsStepComponent', () => {
     expect(controls.preregLinkInfo.value).toBe(PreregLinkInfo.Both);
   });
 
+  it('should default showDeleteButton to false', () => {
+    setup();
+
+    expect(component.showDeleteButton()).toBe(false);
+  });
+
+  it('should update showDeleteButton when input changes', () => {
+    setup();
+
+    fixture.componentRef.setInput('showDeleteButton', true);
+    fixture.detectChanges();
+
+    expect(component.showDeleteButton()).toBe(true);
+  });
+
   it('should enable coiStatement control when hasCoi becomes true', () => {
     setup({ detectChanges: true });
     component.authorAssertionsForm.controls.hasCoi.setValue(true);

--- a/src/app/features/preprints/components/stepper/author-assertion-step/author-assertions-step.component.ts
+++ b/src/app/features/preprints/components/stepper/author-assertion-step/author-assertions-step.component.ts
@@ -10,7 +10,7 @@ import { Textarea } from 'primeng/textarea';
 import { Tooltip } from 'primeng/tooltip';
 
 import { NgClass } from '@angular/common';
-import { ChangeDetectionStrategy, Component, effect, inject, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, effect, inject, input, output } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import {
   AbstractControl,
@@ -124,6 +124,7 @@ export class AuthorAssertionsStepComponent {
     initialValue: this.createdPreprint()?.hasPreregLinks ?? ApplicabilityStatus.NotApplicable,
   });
 
+  showDeleteButton = input(false);
   nextClicked = output<void>();
   backClicked = output<void>();
   deleteClicked = output<void>();

--- a/src/app/features/preprints/components/stepper/file-step/file-step.component.html
+++ b/src/app/features/preprints/components/stepper/file-step/file-step.component.html
@@ -143,13 +143,15 @@
     severity="info"
     (onClick)="backButtonClicked()"
   />
-  <p-button
-    class="w-6 md:w-6rem"
-    styleClass="w-full"
-    [label]="'common.buttons.delete' | translate"
-    severity="danger"
-    (onClick)="deletePreprint()"
-  />
+  @if (showDeleteButton()) {
+    <p-button
+      class="w-6 md:w-6rem"
+      styleClass="w-full"
+      [label]="'common.buttons.delete' | translate"
+      severity="danger"
+      (onClick)="deletePreprint()"
+    />
+  }
   <p-button
     class="w-6 md:w-9rem"
     styleClass="w-full"

--- a/src/app/features/preprints/components/stepper/file-step/file-step.component.spec.ts
+++ b/src/app/features/preprints/components/stepper/file-step/file-step.component.spec.ts
@@ -25,7 +25,6 @@ import { FilesTreeComponent } from '@osf/shared/components/files-tree/files-tree
 import { IconComponent } from '@osf/shared/components/icon/icon.component';
 import { FileModel } from '@osf/shared/models/files/file.model';
 import { FileFolderModel } from '@osf/shared/models/files/file-folder.model';
-import { CustomConfirmationService } from '@osf/shared/services/custom-confirmation.service';
 import { ToastService } from '@osf/shared/services/toast.service';
 
 import { FileStepComponent } from './file-step.component';
@@ -34,10 +33,6 @@ import { OSF_FILE_MOCK } from '@testing/mocks/osf-file.mock';
 import { PREPRINT_MOCK } from '@testing/mocks/preprint.mock';
 import { PREPRINT_PROVIDER_DETAILS_MOCK } from '@testing/mocks/preprint-provider-details';
 import { provideOSFCore } from '@testing/osf.testing.provider';
-import {
-  CustomConfirmationServiceMock,
-  CustomConfirmationServiceMockType,
-} from '@testing/providers/custom-confirmation-provider.mock';
 import { mergeSignalOverrides, provideMockStore, SignalOverride } from '@testing/providers/store-provider.mock';
 import { ToastServiceMock, ToastServiceMockType } from '@testing/providers/toast-provider.mock';
 
@@ -46,7 +41,6 @@ describe('FileStepComponent', () => {
   let fixture: ComponentFixture<FileStepComponent>;
   let store: Store;
   let toastServiceMock: ToastServiceMockType;
-  let confirmationServiceMock: CustomConfirmationServiceMockType;
   const originalPointerEvent = (globalThis as unknown as { PointerEvent?: typeof Event }).PointerEvent;
 
   const mockProvider: PreprintProviderDetails = PREPRINT_PROVIDER_DETAILS_MOCK;
@@ -81,16 +75,10 @@ describe('FileStepComponent', () => {
   }) {
     const signals = mergeSignalOverrides(defaultSignals, overrides?.selectorOverrides);
     toastServiceMock = ToastServiceMock.simple();
-    confirmationServiceMock = CustomConfirmationServiceMock.simple();
 
     TestBed.configureTestingModule({
       imports: [FileStepComponent, ...MockComponents(IconComponent, FilesTreeComponent)],
-      providers: [
-        provideOSFCore(),
-        MockProvider(ToastService, toastServiceMock),
-        MockProvider(CustomConfirmationService, confirmationServiceMock),
-        provideMockStore({ signals }),
-      ],
+      providers: [provideOSFCore(), MockProvider(ToastService, toastServiceMock), provideMockStore({ signals })],
     });
 
     store = TestBed.inject(Store);
@@ -347,5 +335,20 @@ describe('FileStepComponent', () => {
     component.onLoadFiles({ link: '/v2/nodes/node-456/files/', page: 3 });
 
     expect(store.dispatch).toHaveBeenCalledWith(new FetchProjectFilesByLink('/v2/nodes/node-456/files/', 3));
+  });
+
+  it('should default showDeleteButton to false', () => {
+    setup();
+
+    expect(component.showDeleteButton()).toBe(false);
+  });
+
+  it('should update showDeleteButton when input changes', () => {
+    setup();
+
+    fixture.componentRef.setInput('showDeleteButton', true);
+    fixture.detectChanges();
+
+    expect(component.showDeleteButton()).toBe(true);
   });
 });

--- a/src/app/features/preprints/components/stepper/file-step/file-step.component.ts
+++ b/src/app/features/preprints/components/stepper/file-step/file-step.component.ts
@@ -46,7 +46,6 @@ import { ClearFileDirective } from '@osf/shared/directives/clear-file.directive'
 import { StringOrNull } from '@osf/shared/helpers/types.helper';
 import { FileModel } from '@osf/shared/models/files/file.model';
 import { FileFolderModel } from '@osf/shared/models/files/file-folder.model';
-import { CustomConfirmationService } from '@osf/shared/services/custom-confirmation.service';
 import { ToastService } from '@osf/shared/services/toast.service';
 
 @Component({
@@ -71,7 +70,6 @@ import { ToastService } from '@osf/shared/services/toast.service';
 })
 export class FileStepComponent implements OnInit {
   private toastService = inject(ToastService);
-  private customConfirmationService = inject(CustomConfirmationService);
   private destroyRef = inject(DestroyRef);
 
   private actions = createDispatchMap({
@@ -90,6 +88,7 @@ export class FileStepComponent implements OnInit {
   readonly PreprintFileSource = PreprintFileSource;
 
   provider = input.required<PreprintProviderDetails>();
+  showDeleteButton = input(false);
   preprint = select(PreprintStepperSelectors.getPreprint);
   selectedFileSource = select(PreprintStepperSelectors.getSelectedFileSource);
   fileUploadLink = select(PreprintStepperSelectors.getUploadLink);

--- a/src/app/features/preprints/components/stepper/preprints-metadata-step/preprints-metadata-step.component.html
+++ b/src/app/features/preprints/components/stepper/preprints-metadata-step/preprints-metadata-step.component.html
@@ -106,13 +106,15 @@
     severity="info"
     (onClick)="backButtonClicked()"
   />
-  <p-button
-    class="w-6 md:w-6rem"
-    styleClass="w-full"
-    [label]="'common.buttons.delete' | translate"
-    severity="danger"
-    (onClick)="deletePreprint()"
-  />
+  @if (showDeleteButton()) {
+    <p-button
+      class="w-6 md:w-6rem"
+      styleClass="w-full"
+      [label]="'common.buttons.delete' | translate"
+      severity="danger"
+      (onClick)="deletePreprint()"
+    />
+  }
   <p-button
     class="w-6 md:w-9rem"
     styleClass="w-full"

--- a/src/app/features/preprints/components/stepper/preprints-metadata-step/preprints-metadata-step.component.spec.ts
+++ b/src/app/features/preprints/components/stepper/preprints-metadata-step/preprints-metadata-step.component.spec.ts
@@ -184,6 +184,21 @@ describe('PreprintsMetadataStepComponent', () => {
     expect(nextClickedSpy).toHaveBeenCalled();
   });
 
+  it('should default showDeleteButton to false', () => {
+    setup();
+
+    expect(component.showDeleteButton()).toBe(false);
+  });
+
+  it('should update showDeleteButton when input changes', () => {
+    setup();
+
+    fixture.componentRef.setInput('showDeleteButton', true);
+    fixture.detectChanges();
+
+    expect(component.showDeleteButton()).toBe(true);
+  });
+
   it('should dispatch save license from createLicense', () => {
     setup({ detectChanges: false });
     component.createLicense({ id: MOCK_LICENSE.id, licenseOptions: { year: '2024', copyrightHolders: 'A' } });

--- a/src/app/features/preprints/components/stepper/preprints-metadata-step/preprints-metadata-step.component.ts
+++ b/src/app/features/preprints/components/stepper/preprints-metadata-step/preprints-metadata-step.component.ts
@@ -63,6 +63,7 @@ export class PreprintsMetadataStepComponent implements OnInit {
   private toastService = inject(ToastService);
 
   provider = input.required<PreprintProviderDetails>();
+  showDeleteButton = input(false);
   nextClicked = output<void>();
   backClicked = output<void>();
   deleteClicked = output<void>();

--- a/src/app/features/preprints/components/stepper/review-step/review-step.component.html
+++ b/src/app/features/preprints/components/stepper/review-step/review-step.component.html
@@ -240,14 +240,16 @@
     [disabled]="isPreprintSubmitting()"
     (onClick)="cancelSubmission()"
   />
-  <p-button
-    class="w-6 md:w-6rem"
-    styleClass="w-full"
-    [label]="'common.buttons.delete' | translate"
-    severity="danger"
-    [disabled]="isPreprintSubmitting()"
-    (onClick)="deletePreprint()"
-  />
+  @if (showDeleteButton()) {
+    <p-button
+      class="w-6 md:w-6rem"
+      styleClass="w-full"
+      [label]="'common.buttons.delete' | translate"
+      severity="danger"
+      [disabled]="isPreprintSubmitting()"
+      (onClick)="deletePreprint()"
+    />
+  }
   <p-button
     data-test-submit-button
     class="w-6 md:w-9rem"

--- a/src/app/features/preprints/components/stepper/review-step/review-step.component.spec.ts
+++ b/src/app/features/preprints/components/stepper/review-step/review-step.component.spec.ts
@@ -253,4 +253,19 @@ describe('ReviewStepComponent', () => {
 
     expect(emitSpy).toHaveBeenCalled();
   });
+
+  it('should default showDeleteButton to false', () => {
+    setup();
+
+    expect(component.showDeleteButton()).toBe(false);
+  });
+
+  it('should update showDeleteButton when input changes', () => {
+    setup();
+
+    fixture.componentRef.setInput('showDeleteButton', true);
+    fixture.detectChanges();
+
+    expect(component.showDeleteButton()).toBe(true);
+  });
 });

--- a/src/app/features/preprints/components/stepper/review-step/review-step.component.ts
+++ b/src/app/features/preprints/components/stepper/review-step/review-step.component.ts
@@ -59,6 +59,7 @@ export class ReviewStepComponent implements OnInit {
   private readonly toastService = inject(ToastService);
 
   readonly provider = input.required<PreprintProviderDetails>();
+  readonly showDeleteButton = input(false);
   readonly deleteClicked = output<void>();
 
   private readonly actions = createDispatchMap({

--- a/src/app/features/preprints/components/stepper/supplements-step/supplements-step.component.html
+++ b/src/app/features/preprints/components/stepper/supplements-step/supplements-step.component.html
@@ -90,14 +90,16 @@
     severity="info"
     (onClick)="backButtonClicked()"
   />
-  <p-button
-    class="w-6 md:w-6rem"
-    styleClass="w-full"
-    [label]="'common.buttons.delete' | translate"
-    severity="danger"
-    [disabled]="isPreprintSubmitting()"
-    (onClick)="deletePreprint()"
-  />
+  @if (showDeleteButton()) {
+    <p-button
+      class="w-6 md:w-6rem"
+      styleClass="w-full"
+      [label]="'common.buttons.delete' | translate"
+      severity="danger"
+      [disabled]="isPreprintSubmitting()"
+      (onClick)="deletePreprint()"
+    />
+  }
   <p-button
     class="w-6 md:w-9rem"
     styleClass="w-full"

--- a/src/app/features/preprints/components/stepper/supplements-step/supplements-step.component.spec.ts
+++ b/src/app/features/preprints/components/stepper/supplements-step/supplements-step.component.spec.ts
@@ -120,6 +120,21 @@ describe('SupplementsStepComponent', () => {
     expect(store.dispatch).not.toHaveBeenCalledWith(expect.any(FetchPreprintProject));
   });
 
+  it('should default showDeleteButton to false', () => {
+    setup();
+
+    expect(component.showDeleteButton()).toBe(false);
+  });
+
+  it('should update showDeleteButton when input changes', () => {
+    setup();
+
+    fixture.componentRef.setInput('showDeleteButton', true);
+    fixture.detectChanges();
+
+    expect(component.showDeleteButton()).toBe(true);
+  });
+
   it('should dispatch available projects from debounced project search', fakeAsync(() => {
     setup();
     (store.dispatch as jest.Mock).mockClear();

--- a/src/app/features/preprints/components/stepper/supplements-step/supplements-step.component.ts
+++ b/src/app/features/preprints/components/stepper/supplements-step/supplements-step.component.ts
@@ -17,6 +17,7 @@ import {
   DestroyRef,
   effect,
   inject,
+  input,
   OnInit,
   output,
   signal,
@@ -83,6 +84,7 @@ export class SupplementsStepComponent implements OnInit {
   selectedSupplementOption = signal<SupplementOptions>(SupplementOptions.None);
   selectedProjectId = signal<StringOrNull>(null);
 
+  showDeleteButton = input(false);
   nextClicked = output<void>();
   backClicked = output<void>();
   deleteClicked = output<void>();

--- a/src/app/features/preprints/components/stepper/title-and-abstract-step/title-and-abstract-step.component.html
+++ b/src/app/features/preprints/components/stepper/title-and-abstract-step/title-and-abstract-step.component.html
@@ -53,6 +53,15 @@
     severity="info"
     [routerLink]="['/preprints', providerId(), 'discover']"
   />
+  @if (showDeleteButton()) {
+    <p-button
+      class="w-6 md:w-6rem"
+      styleClass="w-full"
+      [label]="'common.buttons.delete' | translate"
+      severity="danger"
+      (onClick)="deletePreprint()"
+    />
+  }
   <p-button
     data-test-next-button
     class="w-6 md:w-9rem"

--- a/src/app/features/preprints/components/stepper/title-and-abstract-step/title-and-abstract-step.component.spec.ts
+++ b/src/app/features/preprints/components/stepper/title-and-abstract-step/title-and-abstract-step.component.spec.ts
@@ -90,6 +90,21 @@ describe('TitleAndAbstractStepComponent', () => {
     expect(component.titleAndAbstractForm.controls.description.value).toBe(mockPreprint.description);
   });
 
+  it('should default showDeleteButton to false', () => {
+    setup();
+
+    expect(component.showDeleteButton()).toBe(false);
+  });
+
+  it('should update showDeleteButton when input changes', () => {
+    setup();
+
+    fixture.componentRef.setInput('showDeleteButton', true);
+    fixture.detectChanges();
+
+    expect(component.showDeleteButton()).toBe(true);
+  });
+
   it('should not dispatch or emit when form is invalid', () => {
     setup();
     const emitSpy = jest.spyOn(component.nextClicked, 'emit');
@@ -115,6 +130,15 @@ describe('TitleAndAbstractStepComponent', () => {
     const emitSpy = jest.spyOn(component.nextClicked, 'emit');
 
     component.nextButtonClicked();
+
+    expect(emitSpy).toHaveBeenCalled();
+  });
+
+  it('should emit deleteClicked when deletePreprint is called', () => {
+    setup();
+    const emitSpy = jest.spyOn(component.deleteClicked, 'emit');
+
+    component.deletePreprint();
 
     expect(emitSpy).toHaveBeenCalled();
   });

--- a/src/app/features/preprints/components/stepper/title-and-abstract-step/title-and-abstract-step.component.ts
+++ b/src/app/features/preprints/components/stepper/title-and-abstract-step/title-and-abstract-step.component.ts
@@ -46,7 +46,9 @@ export class TitleAndAbstractStepComponent {
   private readonly toastService = inject(ToastService);
 
   readonly providerId = input.required<string>();
+  readonly showDeleteButton = input(false);
   readonly nextClicked = output<void>();
+  readonly deleteClicked = output<void>();
 
   private readonly actions = createDispatchMap({
     createPreprint: CreatePreprint,
@@ -84,6 +86,10 @@ export class TitleAndAbstractStepComponent {
         description: createdPreprint.description,
       });
     });
+  }
+
+  deletePreprint() {
+    this.deleteClicked.emit();
   }
 
   nextButtonClicked(): void {

--- a/src/app/features/preprints/pages/create-new-version/create-new-version.component.html
+++ b/src/app/features/preprints/pages/create-new-version/create-new-version.component.html
@@ -38,13 +38,14 @@
       @case (PreprintSteps.File) {
         <osf-file-step
           [provider]="provider"
+          [showDeleteButton]="true"
           (nextClicked)="moveToNextStep()"
           (backClicked)="navigateBack()"
           (deleteClicked)="requestDeletePreprint()"
         />
       }
       @case (PreprintSteps.Review) {
-        <osf-review-step [provider]="provider" (deleteClicked)="requestDeletePreprint()" />
+        <osf-review-step [provider]="provider" [showDeleteButton]="true" (deleteClicked)="requestDeletePreprint()" />
       }
     }
   </section>

--- a/src/app/features/preprints/pages/submit-preprint-stepper/submit-preprint-stepper.component.html
+++ b/src/app/features/preprints/pages/submit-preprint-stepper/submit-preprint-stepper.component.html
@@ -41,6 +41,7 @@
       @case (PreprintSteps.File) {
         <osf-file-step
           [provider]="provider"
+          [showDeleteButton]="true"
           (nextClicked)="moveToNextStep()"
           (backClicked)="moveToPreviousStep()"
           (deleteClicked)="requestDeletePreprint()"
@@ -49,6 +50,7 @@
       @case (PreprintSteps.Metadata) {
         <osf-preprints-metadata
           [provider]="provider"
+          [showDeleteButton]="true"
           (nextClicked)="moveToNextStep()"
           (backClicked)="moveToPreviousStep()"
           (deleteClicked)="requestDeletePreprint()"
@@ -56,6 +58,7 @@
       }
       @case (PreprintSteps.AuthorAssertions) {
         <osf-author-assertions-step
+          [showDeleteButton]="true"
           (nextClicked)="moveToNextStep()"
           (backClicked)="moveToPreviousStep()"
           (deleteClicked)="requestDeletePreprint()"
@@ -63,13 +66,14 @@
       }
       @case (PreprintSteps.Supplements) {
         <osf-supplements-step
+          [showDeleteButton]="true"
           (nextClicked)="moveToNextStep()"
           (backClicked)="moveToPreviousStep()"
           (deleteClicked)="requestDeletePreprint()"
         />
       }
       @case (PreprintSteps.Review) {
-        <osf-review-step [provider]="provider" (deleteClicked)="requestDeletePreprint()" />
+        <osf-review-step [provider]="provider" [showDeleteButton]="true" (deleteClicked)="requestDeletePreprint()" />
       }
     }
   </section>

--- a/src/app/features/preprints/pages/update-preprint-stepper/update-preprint-stepper.component.html
+++ b/src/app/features/preprints/pages/update-preprint-stepper/update-preprint-stepper.component.html
@@ -36,26 +36,53 @@
   <section class="flex-1 bg-white px-3 py-4 md:py-4 md:px-4">
     @switch (currentStep().value) {
       @case (PreprintSteps.TitleAndAbstract) {
-        <osf-title-and-abstract-step [providerId]="provider.id" (nextClicked)="moveToNextStep()" />
+        <osf-title-and-abstract-step
+          [providerId]="provider.id"
+          [showDeleteButton]="isPreprintRejected()"
+          (nextClicked)="moveToNextStep()"
+          (deleteClicked)="requestDeletePreprint()"
+        />
       }
       @case (PreprintSteps.File) {
-        <osf-file-step [provider]="provider" (nextClicked)="moveToNextStep()" (backClicked)="moveToPreviousStep()" />
+        <osf-file-step
+          [provider]="provider"
+          [showDeleteButton]="isPreprintRejected()"
+          (nextClicked)="moveToNextStep()"
+          (backClicked)="moveToPreviousStep()"
+          (deleteClicked)="requestDeletePreprint()"
+        />
       }
       @case (PreprintSteps.Metadata) {
         <osf-preprints-metadata
           [provider]="provider"
+          [showDeleteButton]="isPreprintRejected()"
           (nextClicked)="moveToNextStep()"
           (backClicked)="moveToPreviousStep()"
+          (deleteClicked)="requestDeletePreprint()"
         />
       }
       @case (PreprintSteps.AuthorAssertions) {
-        <osf-author-assertions-step (nextClicked)="moveToNextStep()" (backClicked)="moveToPreviousStep()" />
+        <osf-author-assertions-step
+          [showDeleteButton]="isPreprintRejected()"
+          (nextClicked)="moveToNextStep()"
+          (backClicked)="moveToPreviousStep()"
+          (deleteClicked)="requestDeletePreprint()"
+        />
       }
       @case (PreprintSteps.Supplements) {
-        <osf-supplements-step (nextClicked)="moveToNextStep()" (backClicked)="moveToPreviousStep()" />
+        <osf-supplements-step
+          [showDeleteButton]="isPreprintRejected()"
+          (nextClicked)="moveToNextStep()"
+          (backClicked)="moveToPreviousStep()"
+          (deleteClicked)="requestDeletePreprint()"
+        />
       }
       @case (PreprintSteps.Review) {
-        <osf-review-step [provider]="provider" />
+        <osf-review-step
+          [provider]="provider"
+          [showDeleteButton]="isPreprintRejected()"
+          (deleteClicked)="requestDeletePreprint()"
+        />
       }
     }
   </section>

--- a/src/app/features/preprints/pages/update-preprint-stepper/update-preprint-stepper.component.spec.ts
+++ b/src/app/features/preprints/pages/update-preprint-stepper/update-preprint-stepper.component.spec.ts
@@ -24,8 +24,14 @@ import {
 import { submitPreprintSteps } from '../../constants';
 import { PreprintSteps, ReviewsState } from '../../enums';
 import { PreprintProviderDetails } from '../../models';
+import { PreprintDraftDeletionService } from '../../services/preprint-draft-deletion.service';
 import { GetPreprintProviderById, PreprintProvidersSelectors } from '../../store/preprint-providers';
-import { FetchPreprintById, PreprintStepperSelectors, ResetPreprintStepperState } from '../../store/preprint-stepper';
+import {
+  DeletePreprint,
+  FetchPreprintById,
+  PreprintStepperSelectors,
+  ResetPreprintStepperState,
+} from '../../store/preprint-stepper';
 
 import { UpdatePreprintStepperComponent } from './update-preprint-stepper.component';
 
@@ -35,6 +41,10 @@ import { provideOSFCore } from '@testing/osf.testing.provider';
 import { BrandServiceMock, BrandServiceMockType } from '@testing/providers/brand-service.mock';
 import { BrowserTabServiceMock, BrowserTabServiceMockType } from '@testing/providers/browser-tab-service.mock';
 import { HeaderStyleServiceMock, HeaderStyleServiceMockType } from '@testing/providers/header-style-service.mock';
+import {
+  PreprintDraftDeletionServiceMock,
+  PreprintDraftDeletionServiceMockType,
+} from '@testing/providers/preprint-draft-deletion-provider.mock';
 import { ActivatedRouteMockBuilder } from '@testing/providers/route-provider.mock';
 import { mergeSignalOverrides, provideMockStore, SignalOverride } from '@testing/providers/store-provider.mock';
 
@@ -45,6 +55,7 @@ describe('UpdatePreprintStepperComponent', () => {
   let brandServiceMock: BrandServiceMockType;
   let headerStyleMock: HeaderStyleServiceMockType;
   let browserTabMock: BrowserTabServiceMockType;
+  let draftDeletionMock: PreprintDraftDeletionServiceMockType;
 
   const mockProvider: PreprintProviderDetails = PREPRINT_PROVIDER_DETAILS_MOCK;
   const mockPreprint = PREPRINT_MOCK;
@@ -69,6 +80,7 @@ describe('UpdatePreprintStepperComponent', () => {
     brandServiceMock = BrandServiceMock.simple();
     headerStyleMock = HeaderStyleServiceMock.simple();
     browserTabMock = BrowserTabServiceMock.simple();
+    draftDeletionMock = PreprintDraftDeletionServiceMock.simple();
 
     TestBed.configureTestingModule({
       imports: [
@@ -92,6 +104,12 @@ describe('UpdatePreprintStepperComponent', () => {
         MockProvider(IS_WEB, of(true)),
         provideMockStore({ signals }),
       ],
+    });
+
+    TestBed.overrideComponent(UpdatePreprintStepperComponent, {
+      set: {
+        providers: [{ provide: PreprintDraftDeletionService, useValue: draftDeletionMock }],
+      },
     });
 
     store = TestBed.inject(Store);
@@ -308,5 +326,46 @@ describe('UpdatePreprintStepperComponent', () => {
     component.moveToPreviousStep();
 
     expect(component.currentStep()).toEqual(firstStep);
+  });
+
+  it('should return false from isPreprintRejected when preprint is not rejected', () => {
+    setup();
+
+    expect(component.isPreprintRejected()).toBe(false);
+  });
+
+  it('should return true from isPreprintRejected when preprint is rejected', () => {
+    setup({
+      selectorOverrides: [
+        {
+          selector: PreprintStepperSelectors.getPreprint,
+          value: { ...mockPreprint, reviewsState: ReviewsState.Rejected },
+        },
+      ],
+    });
+
+    expect(component.isPreprintRejected()).toBe(true);
+  });
+
+  it('should request draft deletion with update redirect and action callbacks', () => {
+    setup();
+    (store.dispatch as jest.Mock).mockClear();
+
+    component.requestDeletePreprint();
+
+    expect(draftDeletionMock.confirmDeleteDraft).toHaveBeenCalledWith(
+      expect.objectContaining({
+        redirectUrl: '/my-preprints',
+        onDelete: expect.any(Function),
+        onReset: expect.any(Function),
+      })
+    );
+
+    const { onDelete, onReset } = draftDeletionMock.confirmDeleteDraft.mock.calls[0][0];
+    onDelete();
+    onReset();
+
+    expect(store.dispatch).toHaveBeenCalledWith(new DeletePreprint());
+    expect(store.dispatch).toHaveBeenCalledWith(new ResetPreprintStepperState());
   });
 });

--- a/src/app/features/preprints/pages/update-preprint-stepper/update-preprint-stepper.component.ts
+++ b/src/app/features/preprints/pages/update-preprint-stepper/update-preprint-stepper.component.ts
@@ -38,8 +38,14 @@ import {
 } from '../../components';
 import { submitPreprintSteps } from '../../constants';
 import { PreprintSteps, ProviderReviewsWorkflow, ReviewsState } from '../../enums';
+import { PreprintDraftDeletionService } from '../../services/preprint-draft-deletion.service';
 import { GetPreprintProviderById, PreprintProvidersSelectors } from '../../store/preprint-providers';
-import { FetchPreprintById, PreprintStepperSelectors, ResetPreprintStepperState } from '../../store/preprint-stepper';
+import {
+  DeletePreprint,
+  FetchPreprintById,
+  PreprintStepperSelectors,
+  ResetPreprintStepperState,
+} from '../../store/preprint-stepper';
 
 @Component({
   selector: 'osf-update-preprint-stepper',
@@ -57,6 +63,7 @@ import { FetchPreprintById, PreprintStepperSelectors, ResetPreprintStepperState 
   templateUrl: './update-preprint-stepper.component.html',
   styleUrl: './update-preprint-stepper.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [PreprintDraftDeletionService],
 })
 export class UpdatePreprintStepperComponent implements OnDestroy, CanDeactivateComponent {
   @HostBinding('class') classes = 'flex-1 flex flex-column w-full';
@@ -65,6 +72,7 @@ export class UpdatePreprintStepperComponent implements OnDestroy, CanDeactivateC
   private readonly brandService = inject(BrandService);
   private readonly headerStyleHelper = inject(HeaderStyleService);
   private readonly browserTabHelper = inject(BrowserTabService);
+  private readonly draftDeletionService = inject(PreprintDraftDeletionService);
 
   private providerId = toSignal(this.route.params.pipe(map((params) => params['providerId'])));
   private preprintId = toSignal(this.route.params.pipe(map((params) => params['preprintId'])));
@@ -73,6 +81,7 @@ export class UpdatePreprintStepperComponent implements OnDestroy, CanDeactivateC
     getPreprintProviderById: GetPreprintProviderById,
     resetState: ResetPreprintStepperState,
     fetchPreprint: FetchPreprintById,
+    deletePreprint: DeletePreprint,
   });
 
   preprintProvider = select(PreprintProvidersSelectors.getPreprintProviderDetails(this.providerId()));
@@ -93,6 +102,8 @@ export class UpdatePreprintStepperComponent implements OnDestroy, CanDeactivateC
 
     return providerIsPremod && preprintIsRejected;
   });
+
+  isPreprintRejected = computed(() => this.preprint()?.reviewsState === ReviewsState.Rejected);
 
   readonly updateSteps = computed(() => {
     const provider = this.preprintProvider();
@@ -174,5 +185,13 @@ export class UpdatePreprintStepperComponent implements OnDestroy, CanDeactivateC
     if (prevStep) {
       this.currentStep.set(prevStep);
     }
+  }
+
+  requestDeletePreprint(): void {
+    this.draftDeletionService.confirmDeleteDraft({
+      onDelete: () => this.actions.deletePreprint(),
+      onReset: () => this.actions.resetState(),
+      redirectUrl: '/my-preprints',
+    });
   }
 }


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the correct branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `feat(ENG-123): some really great stuff`
-->

- Ticket: [[ENG-10371]](https://openscience.atlassian.net/browse/ENG-10371)
- Feature flag: n/a

## Summary of Changes
1. Added logic for showing delete button.
2. Added delete button for update preprint.

## Screenshot(s)
<img width="1140" height="897" alt="image" src="https://github.com/user-attachments/assets/7a5d89b4-8127-4d0e-82e9-16b92ba584ee" />
<img width="1151" height="900" alt="image" src="https://github.com/user-attachments/assets/fec40e82-e4c2-41d4-a44e-7ecd6d03742a" />
