### PR TITLE
[ENG-10320] Github: File context menu missing move option

### DIFF
--- a/src/app/features/files/pages/files/files.component.ts
+++ b/src/app/features/files/pages/files/files.component.ts
@@ -669,7 +669,6 @@ export class FilesComponent {
       [FileMenuType.Rename]: supportedFeatures.includes(SupportedFeature.AddUpdateFiles),
       [FileMenuType.Delete]: supportedFeatures.includes(SupportedFeature.DeleteFiles),
       [FileMenuType.Move]:
-        supportedFeatures.includes(SupportedFeature.CopyInto) &&
         supportedFeatures.includes(SupportedFeature.DeleteFiles) &&
         supportedFeatures.includes(SupportedFeature.AddUpdateFiles),
       [FileMenuType.Embed]: true,

--- a/src/app/shared/components/files-tree/files-tree.component.html
+++ b/src/app/shared/components/files-tree/files-tree.component.html
@@ -72,7 +72,7 @@
                 <div class="files-table-cell">
                   @if (file.extra.downloads) {
                     {{
-                      file.kind === 'file' ? file.extra.downloads + ' ' + ('common.buttons.downloads' | translate) : ''
+                      file.kind === 'file' ? file.extra.downloads + ' ' + ('common.labels.downloads' | translate) : ''
                     }}
                   }
                 </div>


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the correct branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `feat(ENG-123): some really great stuff`
-->

- Ticket: https://openscience.atlassian.net/browse/ENG-10320
- Feature flag: n/a

## Summary of Changes
1. Update file context menu to have move option.

## Screenshot(s)
<img width="1235" height="897" alt="image" src="https://github.com/user-attachments/assets/7631f67a-7e31-4ba8-91bc-9288f07144a1" />
