### PR TITLE
[ENG-10831] Profile: Expand buttons are too close to each other

### DIFF
--- a/src/app/features/registries/components/registries-metadata-step/registries-license/registries-license.component.html
+++ b/src/app/features/registries/components/registries-metadata-step/registries-license/registries-license.component.html
@@ -1,5 +1,5 @@
 <p-card class="w-full card mt-4" (focusout)="onFocusOut()">
-  <h2 class="mb-2">{{ 'shared.license.title' | translate }}</h2>
+  <h2 class="mb-2">{{ 'common.labels.license' | translate }}</h2>
 
   <p class="mb-1">{{ 'shared.license.description' | translate }}</p>
   <p>

--- a/src/app/shared/components/education-history/education-history.component.html
+++ b/src/app/shared/components/education-history/education-history.component.html
@@ -1,4 +1,4 @@
-<p-accordion class="card-accordion">
+<p-accordion class="card-accordion flex flex-column gap-4" [multiple]="true">
   @for (education of education(); track $index) {
     <p-accordion-panel value="{{ $index }}" class="accordion-panel">
       <p-accordion-header>

--- a/src/app/shared/components/employment-history/employment-history.component.html
+++ b/src/app/shared/components/employment-history/employment-history.component.html
@@ -1,4 +1,4 @@
-<p-accordion class="card-accordion">
+<p-accordion class="card-accordion flex flex-column gap-4" [multiple]="true">
   @for (employment of employment(); track $index) {
     <p-accordion-panel [value]="$index">
       <p-accordion-header>

--- a/src/app/shared/components/my-projects-table/my-projects-table.component.html
+++ b/src/app/shared/components/my-projects-table/my-projects-table.component.html
@@ -24,7 +24,7 @@
         <p-sortIcon field="title" />
       </th>
 
-      <th>{{ 'myProjects.table.columns.contributors' | translate }}</th>
+      <th>{{ 'common.labels.contributors' | translate }}</th>
 
       <th pSortableColumn="dateModified">
         {{ 'common.labels.modified' | translate }}


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the correct branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `feat(ENG-123): some really great stuff`
-->

- Ticket: https://openscience.atlassian.net/browse/ENG-10831
- Feature flag: n/a

## Summary of Changes
1. Fixed translations.
2. Fixed gap between buttons in profile.

## Screenshot(s)

<img width="1425" height="906" alt="image" src="https://github.com/user-attachments/assets/0961e040-0276-4ffe-b4a3-e20c72fccb18" />
