### PR TITLE
[ENG-10829] Embargoed Registration — End Embargo Early Button Missing

### DIFF
--- a/src/app/features/registry/components/registry-statuses/registry-statuses.component.html
+++ b/src/app/features/registry/components/registry-statuses/registry-statuses.component.html
@@ -1,17 +1,16 @@
 <p-accordion class="accordion-border px-4 py-4 flex-1 no-padding">
   <p-accordion-panel value="0">
     <p-accordion-header class="flex flex-row column-gap-3 align-items-center">
-      <p class="font-bold">{{ 'registry.overview.statuses.' + registry()?.status + '.text' | translate }}</p>
+      <p class="font-bold">{{ statusTranslations().text | translate }}</p>
     </p-accordion-header>
 
     <p-accordion-content>
       <div class="flex flex-column pt-4 gap-2">
-        <h3 class="font-normal">{{ 'registry.overview.statuses.' + registry()?.status + '.short' | translate }}</h3>
+        <h3 class="font-normal">{{ statusTranslations().short | translate }}</h3>
         <p>
           <span>
             {{
-              'registry.overview.statuses.' + registry()?.status + '.long'
-                | translate: { embargoEndDate: embargoEndDate(), email: supportEmail }
+              statusTranslations().long | translate: { embargoEndDate: embargoEndDate(), email: supportEmail }
             }}
           </span>
 

--- a/src/app/features/registry/components/registry-statuses/registry-statuses.component.html
+++ b/src/app/features/registry/components/registry-statuses/registry-statuses.component.html
@@ -9,9 +9,7 @@
         <h3 class="font-normal">{{ statusTranslations().short | translate }}</h3>
         <p>
           <span>
-            {{
-              statusTranslations().long | translate: { embargoEndDate: embargoEndDate(), email: supportEmail }
-            }}
+            {{ statusTranslations().long | translate: { embargoEndDate: embargoEndDate(), email: supportEmail } }}
           </span>
 
           @if (isAccepted()) {

--- a/src/app/features/registry/components/registry-statuses/registry-statuses.component.ts
+++ b/src/app/features/registry/components/registry-statuses/registry-statuses.component.ts
@@ -55,6 +55,23 @@ export class RegistryStatusesComponent {
     return date ? new Date(date).toDateString() : null;
   });
 
+  statusTranslations = computed(() => {
+    const status = this.registry()?.status;
+    if (!status) {
+      return {
+        text: 'registry.overview.endEmbargo',
+        short: 'registry.overview.endEmbargo',
+        long: 'registry.overview.endEmbargo',
+      };
+    }
+    const basePath = `registry.overview.statuses.${status}`;
+    return {
+      text: `${basePath}.text`,
+      short: `${basePath}.short`,
+      long: `${basePath}.long`,
+    };
+  });
+
   openWithdrawDialog(): void {
     const registry = this.registry();
 


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the correct branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `feat(ENG-123): some really great stuff`
-->

- Ticket: https://openscience.atlassian.net/browse/ENG-10829
- Feature flag: n/a

## Purpose

A subset of users are unable to end their embargoed registrations early. The "End Embargo Early" button is not appearing as expected, and users instead see the error text registry.overview.statuses.None.text on the registration overview page. This was previously resolved on a case-by-case basis by cloud engineering, but a permanent fix is now required.

## Summary of Changes

if ``registry.overview.statuses.None.text``

use `registry.overview.endEmbargo` as default for statuses 

## Screenshot(s)

<!-- Attach screenshots if applicable. -->

## Side Effects

https://openscience.atlassian.net/browse/ENG-10829?focusedCommentId=119176

I suppose the solution may be to use registry.overview.endEmbargo as default  if registry()?.status= None  if None might be saved into database only for Embargoed registrations and not affect other status types. Otherwise it may be expected any other approach .

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
