### PR TITLE
[ENG-11004] Account Setting: Code key is displayed instead of button text

### DIFF
--- a/src/app/features/settings/account-settings/components/two-factor-auth/two-factor-auth.component.spec.ts
+++ b/src/app/features/settings/account-settings/components/two-factor-auth/two-factor-auth.component.spec.ts
@@ -89,7 +89,7 @@ describe('TwoFactorAuthComponent', () => {
     expect(confirmationService.confirmAccept).toHaveBeenCalledWith({
       headerKey: 'settings.accountSettings.twoFactorAuth.configure.title',
       messageKey: 'settings.accountSettings.twoFactorAuth.configure.description',
-      acceptLabelKey: 'settings.accountSettings.common.buttons.configure',
+      acceptLabelKey: 'common.buttons.configure',
       onConfirm: expect.any(Function),
     });
 

--- a/src/app/features/settings/account-settings/components/two-factor-auth/two-factor-auth.component.ts
+++ b/src/app/features/settings/account-settings/components/two-factor-auth/two-factor-auth.component.ts
@@ -55,7 +55,7 @@ export class TwoFactorAuthComponent {
     this.customConfirmationService.confirmAccept({
       headerKey: 'settings.accountSettings.twoFactorAuth.configure.title',
       messageKey: 'settings.accountSettings.twoFactorAuth.configure.description',
-      acceptLabelKey: 'settings.accountSettings.common.buttons.configure',
+      acceptLabelKey: 'common.buttons.configure',
       onConfirm: () => {
         this.loaderService.show();
         this.actions.enableTwoFactorAuth().subscribe(() => this.loaderService.hide());

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -2431,7 +2431,6 @@
       "common": {
         "buttons": {
           "deactivate": "Deactivate",
-          "configure": "Configure",
           "enable": "Enable",
           "request": "Request",
           "undo": "Undo"

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -2431,6 +2431,7 @@
       "common": {
         "buttons": {
           "deactivate": "Deactivate",
+          "configure": "Configure",
           "enable": "Enable",
           "request": "Request",
           "undo": "Undo"


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the correct branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `feat(ENG-123): some really great stuff`
-->

- Ticket: https://openscience.atlassian.net/browse/ENG-11004
- Feature flag: n/a

## Purpose

The second button shows text  ...accountsSettings.common.buttons... , the second button should display the proper translated label

## Summary of Changes

 add settings.accountSettings.common.buttons.configure translation to en.json

<img width="1046" height="811" alt="image" src="https://github.com/user-attachments/assets/dd41f479-1b9e-43ab-aba5-01196334e6d4" />


## Screenshot(s)

<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
